### PR TITLE
fix(package.json): remove erroneous comma from dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
     "unity": "2018.3",
     "unityRelease": "10f1",
     "keywords": [
-        "pattern"
+        "pattern",
+        "camerarig",
+        "tracked",
+        "alias",
+        "vr",
+        "ar",
+        "xr",
+        "spatial"
     ],
     "homepage": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.TrackedAlias.Unity/",
     "bugs": {
@@ -23,7 +30,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "1.7.0",
+        "io.extendreality.zinnia.unity": "1.7.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The comma at the end of the dependencies list is not valid and will
cause the build to fail.