### PR TITLE
fix(HowToGuides): provide correct package name in installation guide

### DIFF
--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -56,7 +56,7 @@ The `CameraRigs.TrackedAlias` prefab provides a way of attaching elements to Cam
 
 ### Done
 
-The `Tilia.CameraRigs.TrackedAlias` package will now be available in your Unity project `Packages` directory ready for use in your project.
+The `Tilia CameraRigs TrackedAlias Unity` package will now be available in your Unity project `Packages` directory ready for use in your project.
 
 The package will now also show up in the Unity Package Manager UI. From then on the package can be updated by selecting the package in the Unity Package Manager and clicking on the `Update` button or using the version selection UI.
 


### PR DESCRIPTION
The package name does not include dots and therefore should be written
without any dot separators.