### PR TITLE
fix(Facade): remove isPlaying check from change handler

### DIFF
--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -447,11 +447,6 @@
         [CalledAfterChangeOf(nameof(CameraRigs))]
         protected virtual void OnAfterCameraRigsChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             SubscribeToCameraRigsEvents();
             RefreshCameraRigsConfiguration();
         }


### PR DESCRIPTION
There was an issue with Malimbe where change handler properties
were running at edit time which would cause issues with the setup
of the prefab. The original solution was to add in an isPlaying
check to prevent this. A Malimbe fix has now been pushed so the
latest version of Zinnia now contains the fix in Malimbe and therefore
this check is now no longer required.