### PR TITLE
feat(prefab): emit event when linked tracked alias changes

### DIFF
--- a/Runtime/Prefabs/CameraRigs.TrackedAlias.prefab
+++ b/Runtime/Prefabs/CameraRigs.TrackedAlias.prefab
@@ -425,6 +425,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ActiveSourceChanging:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 8715506455101722365}
   sourceValidity:
@@ -623,6 +628,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ActiveSourceChanging:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 8386388317214558777}
   sourceValidity:
@@ -796,6 +806,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cameraRigs: {fileID: 960702652617744129}
+  TrackedAliasChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Tilia.CameraRigs.TrackedAlias.TrackedAliasFacade+LinkedAliasAssociationCollectionUnityEvent,
+      Tilia.CameraRigs.TrackedAlias.Unity.Runtime, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
   HeadsetTrackingBegun:
     m_PersistentCalls:
       m_Calls: []
@@ -1005,6 +1021,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ActiveSourceChanging:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114148444839838400}
+        m_MethodName: NotifyTrackedAliasChanged
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 8623578196889787470}
   sourceValidity:
@@ -1262,6 +1294,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ActiveSourceChanging:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 1383084746341599450}
   sourceValidity:
@@ -1805,6 +1842,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ActiveSourceChanging:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 5564063951778842142}
   sourceValidity:

--- a/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
@@ -159,6 +159,14 @@
         }
 
         /// <summary>
+        /// Notifies when the tracked alias source has changed.
+        /// </summary>
+        public virtual void NotifyTrackedAliasChanged(GameObject newAlias)
+        {
+            Facade.TrackedAliasChanged?.Invoke(Facade.ActiveLinkedAliasAssociation);
+        }
+
+        /// <summary>
         /// Notifies that the headset has started being tracked.
         /// </summary>
         public virtual void NotifyHeadsetTrackingBegun()

--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -3,6 +3,7 @@
     using Malimbe.MemberChangeMethod;
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
+    using System;
     using System.Collections.Generic;
     using UnityEngine;
     using UnityEngine.Events;
@@ -10,6 +11,7 @@
     using Zinnia.Haptics;
     using Zinnia.Tracking.CameraRig;
     using Zinnia.Tracking.CameraRig.Collection;
+    using Zinnia.Tracking.Collision.Active;
     using Zinnia.Tracking.Follow;
     using Zinnia.Tracking.Velocity;
 
@@ -18,6 +20,12 @@
     /// </summary>
     public class TrackedAliasFacade : MonoBehaviour
     {
+        /// <summary>
+        /// Defines the event with the <see cref="LinkedAliasAssociationCollection"/>.
+        /// </summary>
+        [Serializable]
+        public class LinkedAliasAssociationCollectionUnityEvent : UnityEvent<LinkedAliasAssociationCollection> { }
+
         #region Tracked Alias Settings
         /// <summary>
         /// The associated CameraRigs to track.
@@ -27,11 +35,15 @@
         public LinkedAliasAssociationCollectionObservableList CameraRigs { get; set; }
         #endregion
 
-        #region Tracking Begun Events
+        #region Tracking Events
+        /// <summary>
+        /// Emitted when the tracked alias is about to change.
+        /// </summary>
+        [Header("Tracking Events")]
+        public LinkedAliasAssociationCollectionUnityEvent TrackedAliasChanged = new LinkedAliasAssociationCollectionUnityEvent();
         /// <summary>
         /// Emitted when the headset starts tracking for the first time.
         /// </summary>
-        [Header("Tracking Begun Events")]
         public UnityEvent HeadsetTrackingBegun = new UnityEvent();
         /// <summary>
         /// Emitted when the left controller starts tracking for the first time.
@@ -52,6 +64,7 @@
         public TrackedAliasConfigurator Configuration { get; protected set; }
         #endregion
 
+        public LinkedAliasAssociationCollection ActiveLinkedAliasAssociation => GetFirstActiveLinkedAliasAssociationCollection(CameraRigs.NonSubscribableElements);
         /// <summary>
         /// Retrieves the active PlayArea that the TrackedAlias is using.
         /// </summary>
@@ -475,6 +488,23 @@
         protected virtual void RefreshCameraRigsConfiguration()
         {
             Configuration.SetUpCameraRigsConfiguration();
+        }
+
+        /// <summary>
+        /// Gets the first active <see cref="LinkedAliasAssociationCollection"/> found in the given collection.
+        /// </summary>
+        /// <param name="collection">The collection to look for the first active in.</param>
+        /// <returns>The found first active element in the collection.</returns>
+        protected virtual LinkedAliasAssociationCollection GetFirstActiveLinkedAliasAssociationCollection(IEnumerable<LinkedAliasAssociationCollection> collection)
+        {
+            foreach (LinkedAliasAssociationCollection element in collection)
+            {
+                if (element.gameObject.activeInHierarchy)
+                {
+                    return element;
+                }
+            }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
A new event is emitted when the linked Tracked Alias changes based
on the knowledge that the headset alias follow source changes.