### PR TITLE
fix(Facade): prevent null exception with canceling haptic profiles

### DIFF
--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -547,6 +547,12 @@
         {
             CancelHapticProcessOnLeftController();
             CancelActiveHapticProfileOnLeftController();
+
+            if (ActiveLeftHapticProfiles == null)
+            {
+                return;
+            }
+
             foreach (HapticProcess process in ActiveLeftHapticProfiles.NonSubscribableElements)
             {
                 process.Cancel();
@@ -596,6 +602,12 @@
         {
             CancelHapticProcessOnRightController();
             CancelActiveHapticProfileOnRightController();
+
+            if (ActiveRightHapticProfiles == null)
+            {
+                return;
+            }
+
             foreach (HapticProcess process in ActiveRightHapticProfiles.NonSubscribableElements)
             {
                 process.Cancel();


### PR DESCRIPTION
There was an issue where calling cancel haptic profiles on a rig
that had no profiles set up (like the simulator) would cause a null
exception error because it would try to access the haptics list on
an object that didn't exist.