### PR TITLE
feat(Facade): expose device details and provide new events

### DIFF
--- a/Documentation/API/TrackedAliasConfigurator.md
+++ b/Documentation/API/TrackedAliasConfigurator.md
@@ -7,6 +7,34 @@ Sets up the Tracked Alias Prefab based on the provided user settings.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Fields]
+  * [cachedCurrentDominantController]
+  * [cachedHeadsetBatteryChargeStatus]
+  * [cachedHeadsetConnectionStatus]
+  * [cachedHeadsetSpatialTrackingType]
+  * [cachedHeadsetTrackingBegun]
+  * [cachedLeftControllerBatteryChargeStatus]
+  * [cachedLeftControllerConnectionStatus]
+  * [cachedLeftControllerSpatialTrackingType]
+  * [cachedLeftControllerTrackingBegun]
+  * [cachedLinkedAlias]
+  * [cachedRightControllerBatteryChargeStatus]
+  * [cachedRightControllerConnectionStatus]
+  * [cachedRightControllerSpatialTrackingType]
+  * [cachedRightControllerTrackingBegun]
+  * [DominantControllerIsChangingEventHandler]
+  * [HeadsetBatteryChargeStatusChangedEventHandler]
+  * [HeadsetConnectionChangedEventHandler]
+  * [HeadsetTrackingBegunEventHandler]
+  * [HeadsetTrackingTypeChangedEventHandler]
+  * [LeftControllerBatteryChargeStatusChangedEventHandler]
+  * [LeftControllerConnectionChangedEventHandler]
+  * [LeftControllerTrackingBegunEventHandler]
+  * [LeftControllerTrackingTypeChangedEventHandler]
+  * [RightControllerBatteryChargeStatusChangedEventHandler]
+  * [RightControllerConnectionChangedEventHandler]
+  * [RightControllerTrackingBegunEventHandler]
+  * [RightControllerTrackingTypeChangedEventHandler]
 * [Properties]
   * [Facade]
   * [Headset]
@@ -20,12 +48,19 @@ Sets up the Tracked Alias Prefab based on the provided user settings.
   * [RightControllerVelocityTrackers]
   * [ValidCameras]
 * [Methods]
+  * [CacheAndRaiseEventWithoutPayload<TValue, TEvent>(TValue, ref TValue, TEvent)]
+  * [CacheAndRaiseEventWithPayload<TValue, TEvent>(TValue, ref TValue, TEvent)]
+  * [CheckAndRaiseEventWithoutPayload<TValue, TEvent>(ref TValue, TValue, TEvent)]
+  * [CheckAndRaiseEventWithPayload<TValue, TEvent>(ref TValue, TValue, TEvent)]
+  * [CheckExistingEventStatus()]
   * [NotifyHeadsetTrackingBegun()]
   * [NotifyLeftControllerTrackingBegun()]
   * [NotifyRightControllerTrackingBegun()]
   * [NotifyTrackedAliasChanged(GameObject)]
   * [OnEnable()]
   * [SetUpCameraRigsConfiguration()]
+  * [SubscribeToDetailsEvents()]
+  * [UnsubscribeToDetailsEvents()]
 
 ## Details
 
@@ -42,6 +77,278 @@ Sets up the Tracked Alias Prefab based on the provided user settings.
 
 ```
 public class TrackedAliasConfigurator : MonoBehaviour
+```
+
+### Fields
+
+#### cachedCurrentDominantController
+
+The current cached dominant controller.
+
+##### Declaration
+
+```
+protected DeviceDetailsRecord cachedCurrentDominantController
+```
+
+#### cachedHeadsetBatteryChargeStatus
+
+The current cached headset battery charge status.
+
+##### Declaration
+
+```
+protected BatteryStatus cachedHeadsetBatteryChargeStatus
+```
+
+#### cachedHeadsetConnectionStatus
+
+The current cached headset connection status.
+
+##### Declaration
+
+```
+protected bool cachedHeadsetConnectionStatus
+```
+
+#### cachedHeadsetSpatialTrackingType
+
+The current cached headset tracking type.
+
+##### Declaration
+
+```
+protected DeviceDetailsRecord.SpatialTrackingType cachedHeadsetSpatialTrackingType
+```
+
+#### cachedHeadsetTrackingBegun
+
+The current cached headset tracking begun status.
+
+##### Declaration
+
+```
+protected bool cachedHeadsetTrackingBegun
+```
+
+#### cachedLeftControllerBatteryChargeStatus
+
+The current cached left controller battery charge status.
+
+##### Declaration
+
+```
+protected BatteryStatus cachedLeftControllerBatteryChargeStatus
+```
+
+#### cachedLeftControllerConnectionStatus
+
+The current cached left controller connection status.
+
+##### Declaration
+
+```
+protected bool cachedLeftControllerConnectionStatus
+```
+
+#### cachedLeftControllerSpatialTrackingType
+
+The current cached left controller tracking type.
+
+##### Declaration
+
+```
+protected DeviceDetailsRecord.SpatialTrackingType cachedLeftControllerSpatialTrackingType
+```
+
+#### cachedLeftControllerTrackingBegun
+
+The current cached left controller tracking begun status.
+
+##### Declaration
+
+```
+protected bool cachedLeftControllerTrackingBegun
+```
+
+#### cachedLinkedAlias
+
+The current cached Linked Alias Association Collection.
+
+##### Declaration
+
+```
+protected LinkedAliasAssociationCollection cachedLinkedAlias
+```
+
+#### cachedRightControllerBatteryChargeStatus
+
+The current cached right controller battery charge status.
+
+##### Declaration
+
+```
+protected BatteryStatus cachedRightControllerBatteryChargeStatus
+```
+
+#### cachedRightControllerConnectionStatus
+
+The current cached right controller connection status.
+
+##### Declaration
+
+```
+protected bool cachedRightControllerConnectionStatus
+```
+
+#### cachedRightControllerSpatialTrackingType
+
+The current cached right controller tracking type.
+
+##### Declaration
+
+```
+protected DeviceDetailsRecord.SpatialTrackingType cachedRightControllerSpatialTrackingType
+```
+
+#### cachedRightControllerTrackingBegun
+
+The current cached right controller tracking begun status.
+
+##### Declaration
+
+```
+protected bool cachedRightControllerTrackingBegun
+```
+
+#### DominantControllerIsChangingEventHandler
+
+The event handler to run when the bubbled dominant controller is changing is raised.
+
+##### Declaration
+
+```
+protected UnityAction<DeviceDetailsRecord> DominantControllerIsChangingEventHandler
+```
+
+#### HeadsetBatteryChargeStatusChangedEventHandler
+
+The event handler to run when the bubbled headset event for battery charge status changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<BatteryStatus> HeadsetBatteryChargeStatusChangedEventHandler
+```
+
+#### HeadsetConnectionChangedEventHandler
+
+The event handler to run when the bubbled headset event for connection changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<bool> HeadsetConnectionChangedEventHandler
+```
+
+#### HeadsetTrackingBegunEventHandler
+
+The event handler to run when the bubbled headset event for tracking begun is raised.
+
+##### Declaration
+
+```
+protected UnityAction HeadsetTrackingBegunEventHandler
+```
+
+#### HeadsetTrackingTypeChangedEventHandler
+
+The event handler to run when the bubbled headset event for tracking type changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<DeviceDetailsRecord.SpatialTrackingType> HeadsetTrackingTypeChangedEventHandler
+```
+
+#### LeftControllerBatteryChargeStatusChangedEventHandler
+
+The event handler to run when the bubbled left controller event for battery charge status changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<BatteryStatus> LeftControllerBatteryChargeStatusChangedEventHandler
+```
+
+#### LeftControllerConnectionChangedEventHandler
+
+The event handler to run when the bubbled left controller event for connection changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<bool> LeftControllerConnectionChangedEventHandler
+```
+
+#### LeftControllerTrackingBegunEventHandler
+
+The event handler to run when the bubbled left controller event for tracking begun is raised.
+
+##### Declaration
+
+```
+protected UnityAction LeftControllerTrackingBegunEventHandler
+```
+
+#### LeftControllerTrackingTypeChangedEventHandler
+
+The event handler to run when the bubbled left controller event for tracking type changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<DeviceDetailsRecord.SpatialTrackingType> LeftControllerTrackingTypeChangedEventHandler
+```
+
+#### RightControllerBatteryChargeStatusChangedEventHandler
+
+The event handler to run when the bubbled right controller event for battery charge status changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<BatteryStatus> RightControllerBatteryChargeStatusChangedEventHandler
+```
+
+#### RightControllerConnectionChangedEventHandler
+
+The event handler to run when the bubbled right controller event for connection changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<bool> RightControllerConnectionChangedEventHandler
+```
+
+#### RightControllerTrackingBegunEventHandler
+
+The event handler to run when the bubbled right controller event for tracking begun is raised.
+
+##### Declaration
+
+```
+protected UnityAction RightControllerTrackingBegunEventHandler
+```
+
+#### RightControllerTrackingTypeChangedEventHandler
+
+The event handler to run when the bubbled right controller event for tracking type changed is raised.
+
+##### Declaration
+
+```
+protected UnityAction<DeviceDetailsRecord.SpatialTrackingType> RightControllerTrackingTypeChangedEventHandler
 ```
 
 ### Properties
@@ -158,6 +465,120 @@ public ListContainsRule ValidCameras { get; protected set; }
 
 ### Methods
 
+#### CacheAndRaiseEventWithoutPayload<TValue, TEvent>(TValue, ref TValue, TEvent)
+
+Caches the given new value and raises the given event.
+
+##### Declaration
+
+```
+protected virtual void CacheAndRaiseEventWithoutPayload<TValue, TEvent>(TValue newValue, ref TValue cachedValue, TEvent output)
+    where TEvent : UnityEvent, new()
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| TValue | newValue | The new value to cache. |
+| TValue | cachedValue | The existing cached value. |
+| TEvent | output | The event to raise. |
+
+##### Type Parameters
+
+| Name | Description |
+| --- | --- |
+| TValue | The variable type of the given values. |
+| TEvent | The UnityEvent type to raise. |
+
+#### CacheAndRaiseEventWithPayload<TValue, TEvent>(TValue, ref TValue, TEvent)
+
+Caches the given new value and raises the given event with the new value as the payload.
+
+##### Declaration
+
+```
+protected virtual void CacheAndRaiseEventWithPayload<TValue, TEvent>(TValue newValue, ref TValue cachedValue, TEvent output)
+    where TEvent : UnityEvent<TValue>, new()
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| TValue | newValue | The new value to cache. |
+| TValue | cachedValue | The existing cached value. |
+| TEvent | output | The event to raise. |
+
+##### Type Parameters
+
+| Name | Description |
+| --- | --- |
+| TValue | The variable type of the given values. |
+| TEvent | The UnityEvent type to raise. |
+
+#### CheckAndRaiseEventWithoutPayload<TValue, TEvent>(ref TValue, TValue, TEvent)
+
+Checks if the two given values equal and raises the given event if they are not.
+
+##### Declaration
+
+```
+protected virtual void CheckAndRaiseEventWithoutPayload<TValue, TEvent>(ref TValue comparer, TValue comparator, TEvent output)
+    where TEvent : UnityEvent, new()
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| TValue | comparer | The source value to compare from. |
+| TValue | comparator | The target value to compare with. |
+| TEvent | output | The event to raise if the two values are not equal. |
+
+##### Type Parameters
+
+| Name | Description |
+| --- | --- |
+| TValue | The variable type to check equality with. |
+| TEvent | The UnityEvent type to raise. |
+
+#### CheckAndRaiseEventWithPayload<TValue, TEvent>(ref TValue, TValue, TEvent)
+
+Checks if the two given values equal and raises the given event with the relevant payload if they are not.
+
+##### Declaration
+
+```
+protected virtual void CheckAndRaiseEventWithPayload<TValue, TEvent>(ref TValue comparer, TValue comparator, TEvent output)
+    where TEvent : UnityEvent<TValue>, new()
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| TValue | comparer | The source value to compare from. |
+| TValue | comparator | The target value to compare with. |
+| TEvent | output | The event to raise if the two values are not equal. |
+
+##### Type Parameters
+
+| Name | Description |
+| --- | --- |
+| TValue | The variable type to check equality with. |
+| TEvent | The UnityEvent type to raise. |
+
+#### CheckExistingEventStatus()
+
+Check the existing status of the event values and raise a new event if it has changed.
+
+##### Declaration
+
+```
+protected virtual void CheckExistingEventStatus()
+```
+
 #### NotifyHeadsetTrackingBegun()
 
 Notifies that the headset has started being tracked.
@@ -195,14 +616,14 @@ Notifies when the tracked alias source has changed.
 ##### Declaration
 
 ```
-public virtual void NotifyTrackedAliasChanged(GameObject newAlias)
+public virtual void NotifyTrackedAliasChanged(GameObject _)
 ```
 
 ##### Parameters
 
 | Type | Name | Description |
 | --- | --- | --- |
-| GameObject | newAlias | n/a |
+| GameObject | \_ | n/a |
 
 #### OnEnable()
 
@@ -222,12 +643,60 @@ Sets up the TrackedAlias prefab with the specified settings.
 public virtual void SetUpCameraRigsConfiguration()
 ```
 
+#### SubscribeToDetailsEvents()
+
+Subscribe to the events of each DeviceDetailsRecord.
+
+##### Declaration
+
+```
+protected virtual void SubscribeToDetailsEvents()
+```
+
+#### UnsubscribeToDetailsEvents()
+
+Unsubscribes from the events of each DeviceDetailsRecord.
+
+##### Declaration
+
+```
+protected virtual void UnsubscribeToDetailsEvents()
+```
+
 [Tilia.CameraRigs.TrackedAlias]: README.md
 [TrackedAliasFacade]: TrackedAliasFacade.md
 [ValidCameras]: TrackedAliasConfigurator.md#ValidCameras
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Fields]: #Fields
+[cachedCurrentDominantController]: #cachedCurrentDominantController
+[cachedHeadsetBatteryChargeStatus]: #cachedHeadsetBatteryChargeStatus
+[cachedHeadsetConnectionStatus]: #cachedHeadsetConnectionStatus
+[cachedHeadsetSpatialTrackingType]: #cachedHeadsetSpatialTrackingType
+[cachedHeadsetTrackingBegun]: #cachedHeadsetTrackingBegun
+[cachedLeftControllerBatteryChargeStatus]: #cachedLeftControllerBatteryChargeStatus
+[cachedLeftControllerConnectionStatus]: #cachedLeftControllerConnectionStatus
+[cachedLeftControllerSpatialTrackingType]: #cachedLeftControllerSpatialTrackingType
+[cachedLeftControllerTrackingBegun]: #cachedLeftControllerTrackingBegun
+[cachedLinkedAlias]: #cachedLinkedAlias
+[cachedRightControllerBatteryChargeStatus]: #cachedRightControllerBatteryChargeStatus
+[cachedRightControllerConnectionStatus]: #cachedRightControllerConnectionStatus
+[cachedRightControllerSpatialTrackingType]: #cachedRightControllerSpatialTrackingType
+[cachedRightControllerTrackingBegun]: #cachedRightControllerTrackingBegun
+[DominantControllerIsChangingEventHandler]: #DominantControllerIsChangingEventHandler
+[HeadsetBatteryChargeStatusChangedEventHandler]: #HeadsetBatteryChargeStatusChangedEventHandler
+[HeadsetConnectionChangedEventHandler]: #HeadsetConnectionChangedEventHandler
+[HeadsetTrackingBegunEventHandler]: #HeadsetTrackingBegunEventHandler
+[HeadsetTrackingTypeChangedEventHandler]: #HeadsetTrackingTypeChangedEventHandler
+[LeftControllerBatteryChargeStatusChangedEventHandler]: #LeftControllerBatteryChargeStatusChangedEventHandler
+[LeftControllerConnectionChangedEventHandler]: #LeftControllerConnectionChangedEventHandler
+[LeftControllerTrackingBegunEventHandler]: #LeftControllerTrackingBegunEventHandler
+[LeftControllerTrackingTypeChangedEventHandler]: #LeftControllerTrackingTypeChangedEventHandler
+[RightControllerBatteryChargeStatusChangedEventHandler]: #RightControllerBatteryChargeStatusChangedEventHandler
+[RightControllerConnectionChangedEventHandler]: #RightControllerConnectionChangedEventHandler
+[RightControllerTrackingBegunEventHandler]: #RightControllerTrackingBegunEventHandler
+[RightControllerTrackingTypeChangedEventHandler]: #RightControllerTrackingTypeChangedEventHandler
 [Properties]: #Properties
 [Facade]: #Facade
 [Headset]: #Headset
@@ -241,9 +710,16 @@ public virtual void SetUpCameraRigsConfiguration()
 [RightControllerVelocityTrackers]: #RightControllerVelocityTrackers
 [ValidCameras]: #ValidCameras
 [Methods]: #Methods
+[CacheAndRaiseEventWithoutPayload<TValue, TEvent>(TValue, ref TValue, TEvent)]: #CacheAndRaiseEventWithoutPayload<TValue-TEvent>TValue-ref TValue-TEvent
+[CacheAndRaiseEventWithPayload<TValue, TEvent>(TValue, ref TValue, TEvent)]: #CacheAndRaiseEventWithPayload<TValue-TEvent>TValue-ref TValue-TEvent
+[CheckAndRaiseEventWithoutPayload<TValue, TEvent>(ref TValue, TValue, TEvent)]: #CheckAndRaiseEventWithoutPayload<TValue-TEvent>ref TValue-TValue-TEvent
+[CheckAndRaiseEventWithPayload<TValue, TEvent>(ref TValue, TValue, TEvent)]: #CheckAndRaiseEventWithPayload<TValue-TEvent>ref TValue-TValue-TEvent
+[CheckExistingEventStatus()]: #CheckExistingEventStatus
 [NotifyHeadsetTrackingBegun()]: #NotifyHeadsetTrackingBegun
 [NotifyLeftControllerTrackingBegun()]: #NotifyLeftControllerTrackingBegun
 [NotifyRightControllerTrackingBegun()]: #NotifyRightControllerTrackingBegun
 [NotifyTrackedAliasChanged(GameObject)]: #NotifyTrackedAliasChangedGameObject
 [OnEnable()]: #OnEnable
 [SetUpCameraRigsConfiguration()]: #SetUpCameraRigsConfiguration
+[SubscribeToDetailsEvents()]: #SubscribeToDetailsEvents
+[UnsubscribeToDetailsEvents()]: #UnsubscribeToDetailsEvents

--- a/Documentation/API/TrackedAliasFacade.md
+++ b/Documentation/API/TrackedAliasFacade.md
@@ -8,46 +8,111 @@ The public interface into the Tracked Alias Prefab.
 * [Namespace]
 * [Syntax]
 * [Fields]
+  * [DominantControllerIsChanging]
+  * [HeadsetBatteryChargeStatusChanged]
+  * [HeadsetConnectionStatusChanged]
   * [HeadsetTrackingBegun]
+  * [HeadsetTrackingTypeChanged]
+  * [LeftControllerBatteryChargeStatusChanged]
+  * [LeftControllerConnectionStatusChanged]
   * [LeftControllerTrackingBegun]
+  * [LeftControllerTrackingTypeChanged]
+  * [RightControllerBatteryChargeStatusChanged]
+  * [RightControllerConnectionStatusChanged]
   * [RightControllerTrackingBegun]
+  * [RightControllerTrackingTypeChanged]
   * [TrackedAliasChanged]
 * [Properties]
+  * [ActiveDominantControllerNode]
+  * [ActiveDominantControllerObserver]
+  * [ActiveDominantControllerRecord]
   * [ActiveHeadset]
+  * [ActiveHeadsetBatteryChargeStatus]
+  * [ActiveHeadsetBatteryLevel]
   * [ActiveHeadsetCamera]
+  * [ActiveHeadsetDetails]
+  * [ActiveHeadsetIsConnected]
+  * [ActiveHeadsetManufacturer]
+  * [ActiveHeadsetModel]
+  * [ActiveHeadsetTrackingHasBegun]
+  * [ActiveHeadsetTrackingType]
   * [ActiveHeadsetVelocity]
   * [ActiveLeftController]
+  * [ActiveLeftControllerBatteryChargeStatus]
+  * [ActiveLeftControllerBatteryLevel]
+  * [ActiveLeftControllerDetails]
+  * [ActiveLeftControllerIsConnected]
+  * [ActiveLeftControllerManufacturer]
+  * [ActiveLeftControllerModel]
+  * [ActiveLeftControllerTrackingHasBegun]
+  * [ActiveLeftControllerTrackingType]
   * [ActiveLeftControllerVelocity]
   * [ActiveLeftHapticProcess]
+  * [ActiveLeftHapticProfile]
+  * [ActiveLeftHapticProfiles]
   * [ActiveLinkedAliasAssociation]
   * [ActivePlayArea]
   * [ActiveRightController]
+  * [ActiveRightControllerBatteryChargeStatus]
+  * [ActiveRightControllerBatteryLevel]
+  * [ActiveRightControllerDetails]
+  * [ActiveRightControllerIsConnected]
+  * [ActiveRightControllerManufacturer]
+  * [ActiveRightControllerModel]
+  * [ActiveRightControllerTrackingHasBegun]
+  * [ActiveRightControllerTrackingType]
   * [ActiveRightControllerVelocity]
   * [ActiveRightHapticProcess]
+  * [ActiveRightHapticProfile]
+  * [ActiveRightHapticProfiles]
   * [CameraRigs]
   * [Configuration]
+  * [DominantControllerObservers]
   * [HeadsetAlias]
   * [HeadsetCameras]
+  * [HeadsetDeviceDetailRecords]
   * [HeadsetOriginAlias]
   * [Headsets]
   * [HeadsetSupplementCameras]
   * [HeadsetVelocityTrackers]
   * [LeftControllerAlias]
+  * [LeftControllerDeviceDetailRecords]
   * [LeftControllerHapticProcesses]
+  * [LeftControllerHapticProfiles]
   * [LeftControllers]
   * [LeftControllerVelocityTrackers]
   * [PlayAreaAlias]
   * [PlayAreas]
   * [RightControllerAlias]
+  * [RightControllerDeviceDetailRecords]
   * [RightControllerHapticProcesses]
+  * [RightControllerHapticProfiles]
   * [RightControllers]
   * [RightControllerVelocityTrackers]
 * [Methods]
+  * [BeginHapticProcessOnLeftController()]
+  * [BeginHapticProcessOnLeftController(Int32)]
+  * [BeginHapticProcessOnRightController()]
+  * [BeginHapticProcessOnRightController(Int32)]
+  * [BeginHapticProfile(HapticProcessObservableList, Int32)]
+  * [CancelActiveHapticProfileOnLeftController()]
+  * [CancelActiveHapticProfileOnRightController()]
+  * [CancelAllHapticsOnLeftController()]
+  * [CancelAllHapticsOnRightController()]
+  * [CancelHapticProcessOnLeftController()]
+  * [CancelHapticProcessOnLeftController(Int32)]
+  * [CancelHapticProcessOnRightController()]
+  * [CancelHapticProcessOnRightController(Int32)]
+  * [CancelHapticProfile(HapticProcessObservableList, Int32)]
   * [GetFirstActiveCamera(IEnumerable<Camera>)]
+  * [GetFirstActiveDeviceRecord(IEnumerable<DeviceDetailsRecord>)]
+  * [GetFirstActiveDominantControllerObserver(IEnumerable<DominantControllerObserver>)]
   * [GetFirstActiveGameObject(IEnumerable<GameObject>)]
   * [GetFirstActiveHapticProcess(IEnumerable<HapticProcess>)]
+  * [GetFirstActiveHapticProfile(IEnumerable<HapticProcessObservableList>)]
   * [GetFirstActiveLinkedAliasAssociationCollection(IEnumerable<LinkedAliasAssociationCollection>)]
   * [GetFirstActiveVelocityTracker(IEnumerable<VelocityTracker>)]
+  * [IsValidHapticProfile(HapticProcessObservableList, Int32)]
   * [OnAfterCameraRigsChange()]
   * [OnBeforeCameraRigsChange()]
   * [OnCameraRigAdded(LinkedAliasAssociationCollection)]
@@ -77,6 +142,36 @@ public class TrackedAliasFacade : MonoBehaviour
 
 ### Fields
 
+#### DominantControllerIsChanging
+
+Emitted when the dominant controller is changing.
+
+##### Declaration
+
+```
+public DominantControllerObserver.UnityEvent DominantControllerIsChanging
+```
+
+#### HeadsetBatteryChargeStatusChanged
+
+Emitted when the headset battery charge status changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.BatteryStatusUnityEvent HeadsetBatteryChargeStatusChanged
+```
+
+#### HeadsetConnectionStatusChanged
+
+Emitted when the headset connection status changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.BoolUnityEvent HeadsetConnectionStatusChanged
+```
+
 #### HeadsetTrackingBegun
 
 Emitted when the headset starts tracking for the first time.
@@ -85,6 +180,36 @@ Emitted when the headset starts tracking for the first time.
 
 ```
 public UnityEvent HeadsetTrackingBegun
+```
+
+#### HeadsetTrackingTypeChanged
+
+Emitted when the headset tracking type changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.SpatialTrackingTypeUnityEvent HeadsetTrackingTypeChanged
+```
+
+#### LeftControllerBatteryChargeStatusChanged
+
+Emitted when the left controller battery charge status changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.BatteryStatusUnityEvent LeftControllerBatteryChargeStatusChanged
+```
+
+#### LeftControllerConnectionStatusChanged
+
+Emitted when the left controller connection status changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.BoolUnityEvent LeftControllerConnectionStatusChanged
 ```
 
 #### LeftControllerTrackingBegun
@@ -97,6 +222,36 @@ Emitted when the left controller starts tracking for the first time.
 public UnityEvent LeftControllerTrackingBegun
 ```
 
+#### LeftControllerTrackingTypeChanged
+
+Emitted when the left controller tracking type changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.SpatialTrackingTypeUnityEvent LeftControllerTrackingTypeChanged
+```
+
+#### RightControllerBatteryChargeStatusChanged
+
+Emitted when the right controller battery charge status changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.BatteryStatusUnityEvent RightControllerBatteryChargeStatusChanged
+```
+
+#### RightControllerConnectionStatusChanged
+
+Emitted when the right controller connection status changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.BoolUnityEvent RightControllerConnectionStatusChanged
+```
+
 #### RightControllerTrackingBegun
 
 Emitted when the right controller starts tracking for the first time.
@@ -105,6 +260,16 @@ Emitted when the right controller starts tracking for the first time.
 
 ```
 public UnityEvent RightControllerTrackingBegun
+```
+
+#### RightControllerTrackingTypeChanged
+
+Emitted when the right controller tracking type changes.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.SpatialTrackingTypeUnityEvent RightControllerTrackingTypeChanged
 ```
 
 #### TrackedAliasChanged
@@ -119,6 +284,36 @@ public TrackedAliasFacade.LinkedAliasAssociationCollectionUnityEvent TrackedAlia
 
 ### Properties
 
+#### ActiveDominantControllerNode
+
+Retrieves the dominant connected controller node.
+
+##### Declaration
+
+```
+public XRNode ActiveDominantControllerNode { get; }
+```
+
+#### ActiveDominantControllerObserver
+
+Retrieves the active Headset Detail Record that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DominantControllerObserver ActiveDominantControllerObserver { get; }
+```
+
+#### ActiveDominantControllerRecord
+
+Retrieves the dominant connected controller node.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord ActiveDominantControllerRecord { get; }
+```
+
 #### ActiveHeadset
 
 Retrieves the active Headset that the TrackedAlias is using.
@@ -129,6 +324,26 @@ Retrieves the active Headset that the TrackedAlias is using.
 public GameObject ActiveHeadset { get; }
 ```
 
+#### ActiveHeadsetBatteryChargeStatus
+
+Retrieves the active Headset Detail Battery Charge status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public BatteryStatus ActiveHeadsetBatteryChargeStatus { get; }
+```
+
+#### ActiveHeadsetBatteryLevel
+
+Retrieves the active Headset Detail Battery Level status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public float ActiveHeadsetBatteryLevel { get; }
+```
+
 #### ActiveHeadsetCamera
 
 Retrieves the active Headset Camera that the TrackedAlias is using.
@@ -137,6 +352,66 @@ Retrieves the active Headset Camera that the TrackedAlias is using.
 
 ```
 public Camera ActiveHeadsetCamera { get; }
+```
+
+#### ActiveHeadsetDetails
+
+Retrieves the active Headset Detail Record that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord ActiveHeadsetDetails { get; }
+```
+
+#### ActiveHeadsetIsConnected
+
+Retrieves the active Headset Detail Is Connected status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveHeadsetIsConnected { get; }
+```
+
+#### ActiveHeadsetManufacturer
+
+Retrieves the active Headset Detail Manufacturer status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveHeadsetManufacturer { get; }
+```
+
+#### ActiveHeadsetModel
+
+Retrieves the active Headset Detail Model status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveHeadsetModel { get; }
+```
+
+#### ActiveHeadsetTrackingHasBegun
+
+Retrieves the active Headset Detail Tracking Begun status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveHeadsetTrackingHasBegun { get; }
+```
+
+#### ActiveHeadsetTrackingType
+
+Retrieves the active Headset Detail Tracking Type status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.SpatialTrackingType ActiveHeadsetTrackingType { get; }
 ```
 
 #### ActiveHeadsetVelocity
@@ -159,6 +434,86 @@ Retrieves the active Left Controller that the TrackedAlias is using.
 public GameObject ActiveLeftController { get; }
 ```
 
+#### ActiveLeftControllerBatteryChargeStatus
+
+Retrieves the active LeftController Detail Battery Charge status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public BatteryStatus ActiveLeftControllerBatteryChargeStatus { get; }
+```
+
+#### ActiveLeftControllerBatteryLevel
+
+Retrieves the active LeftController Detail Battery Level status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public float ActiveLeftControllerBatteryLevel { get; }
+```
+
+#### ActiveLeftControllerDetails
+
+Retrieves the active LeftController Detail Record that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord ActiveLeftControllerDetails { get; }
+```
+
+#### ActiveLeftControllerIsConnected
+
+Retrieves the active LeftController Detail Is Connected status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveLeftControllerIsConnected { get; }
+```
+
+#### ActiveLeftControllerManufacturer
+
+Retrieves the active LeftController Detail Manufacturer status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveLeftControllerManufacturer { get; }
+```
+
+#### ActiveLeftControllerModel
+
+Retrieves the active LeftController Detail Model status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveLeftControllerModel { get; }
+```
+
+#### ActiveLeftControllerTrackingHasBegun
+
+Retrieves the active LeftController Detail Tracking Begun status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveLeftControllerTrackingHasBegun { get; }
+```
+
+#### ActiveLeftControllerTrackingType
+
+Retrieves the active LeftController Detail Tracking Type status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.SpatialTrackingType ActiveLeftControllerTrackingType { get; }
+```
+
 #### ActiveLeftControllerVelocity
 
 Retrieves the active Left Controller Velocity Tracker that the TrackedAlias is using.
@@ -177,6 +532,26 @@ Retrieves the active Left Controller Haptic Process that the TrackedAlias is usi
 
 ```
 public HapticProcess ActiveLeftHapticProcess { get; }
+```
+
+#### ActiveLeftHapticProfile
+
+Retrieves the active Left Controller Haptic Profile that has been most recently used.
+
+##### Declaration
+
+```
+public HapticProcess ActiveLeftHapticProfile { get; protected set; }
+```
+
+#### ActiveLeftHapticProfiles
+
+Retrieves the active Left Controller Haptic Profiles that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public HapticProcessObservableList ActiveLeftHapticProfiles { get; }
 ```
 
 #### ActiveLinkedAliasAssociation
@@ -207,6 +582,86 @@ Retrieves the active Right Controller that the TrackedAlias is using.
 public GameObject ActiveRightController { get; }
 ```
 
+#### ActiveRightControllerBatteryChargeStatus
+
+Retrieves the active RightController Detail Battery Charge status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public BatteryStatus ActiveRightControllerBatteryChargeStatus { get; }
+```
+
+#### ActiveRightControllerBatteryLevel
+
+Retrieves the active RightController Detail Battery Level status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public float ActiveRightControllerBatteryLevel { get; }
+```
+
+#### ActiveRightControllerDetails
+
+Retrieves the active RightController Detail Record that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord ActiveRightControllerDetails { get; }
+```
+
+#### ActiveRightControllerIsConnected
+
+Retrieves the active RightController Detail Is Connected status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveRightControllerIsConnected { get; }
+```
+
+#### ActiveRightControllerManufacturer
+
+Retrieves the active RightController Detail Manufacturer status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveRightControllerManufacturer { get; }
+```
+
+#### ActiveRightControllerModel
+
+Retrieves the active RightController Detail Model status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveRightControllerModel { get; }
+```
+
+#### ActiveRightControllerTrackingHasBegun
+
+Retrieves the active RightController Detail Tracking Begun status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveRightControllerTrackingHasBegun { get; }
+```
+
+#### ActiveRightControllerTrackingType
+
+Retrieves the active RightController Detail Tracking Type status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.SpatialTrackingType ActiveRightControllerTrackingType { get; }
+```
+
 #### ActiveRightControllerVelocity
 
 Retrieves the active Right Controller Velocity Tracker that the TrackedAlias is using.
@@ -225,6 +680,26 @@ Retrieves the active Right Controller Haptic Process that the TrackedAlias is us
 
 ```
 public HapticProcess ActiveRightHapticProcess { get; }
+```
+
+#### ActiveRightHapticProfile
+
+Retrieves the active Right Controller Haptic Profile that has been most recently used.
+
+##### Declaration
+
+```
+public HapticProcess ActiveRightHapticProfile { get; protected set; }
+```
+
+#### ActiveRightHapticProfiles
+
+Retrieves the active Left Controller Haptic Profiles that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public HapticProcessObservableList ActiveRightHapticProfiles { get; }
 ```
 
 #### CameraRigs
@@ -247,6 +722,16 @@ The linked Internal Setup.
 public TrackedAliasConfigurator Configuration { get; protected set; }
 ```
 
+#### DominantControllerObservers
+
+Retrieves all of the linked CameraRig Dominant Controller Observers.
+
+##### Declaration
+
+```
+public IEnumerable<DominantControllerObserver> DominantControllerObservers { get; }
+```
+
 #### HeadsetAlias
 
 The alias follower for the Headset.
@@ -265,6 +750,16 @@ Retrieves all of the linked CameraRig Headset Cameras.
 
 ```
 public IEnumerable<Camera> HeadsetCameras { get; }
+```
+
+#### HeadsetDeviceDetailRecords
+
+Retrieves all of the linked CameraRig Headset Device Detail Record.
+
+##### Declaration
+
+```
+public IEnumerable<DeviceDetailsRecord> HeadsetDeviceDetailRecords { get; }
 ```
 
 #### HeadsetOriginAlias
@@ -317,6 +812,16 @@ The alias follower for the LeftController.
 public ObjectFollower LeftControllerAlias { get; }
 ```
 
+#### LeftControllerDeviceDetailRecords
+
+Retrieves all of the linked CameraRig Left Controller Device Detail Record.
+
+##### Declaration
+
+```
+public IEnumerable<DeviceDetailsRecord> LeftControllerDeviceDetailRecords { get; }
+```
+
 #### LeftControllerHapticProcesses
 
 Retrieves all of the linked CameraRig Left Controller Haptic Processes.
@@ -325,6 +830,16 @@ Retrieves all of the linked CameraRig Left Controller Haptic Processes.
 
 ```
 public IEnumerable<HapticProcess> LeftControllerHapticProcesses { get; }
+```
+
+#### LeftControllerHapticProfiles
+
+Retrieves all of the linked CameraRig Left Controller Haptic Profiles.
+
+##### Declaration
+
+```
+public IEnumerable<HapticProcessObservableList> LeftControllerHapticProfiles { get; }
 ```
 
 #### LeftControllers
@@ -377,6 +892,16 @@ The alias follower for the RightController.
 public ObjectFollower RightControllerAlias { get; }
 ```
 
+#### RightControllerDeviceDetailRecords
+
+Retrieves all of the linked CameraRig Right Controller Device Detail Record.
+
+##### Declaration
+
+```
+public IEnumerable<DeviceDetailsRecord> RightControllerDeviceDetailRecords { get; }
+```
+
 #### RightControllerHapticProcesses
 
 Retrieves all of the linked CameraRig Right Controller Haptic Processes.
@@ -385,6 +910,16 @@ Retrieves all of the linked CameraRig Right Controller Haptic Processes.
 
 ```
 public IEnumerable<HapticProcess> RightControllerHapticProcesses { get; }
+```
+
+#### RightControllerHapticProfiles
+
+Retrieves all of the linked CameraRig Right Controller Haptic Processes.
+
+##### Declaration
+
+```
+public IEnumerable<HapticProcessObservableList> RightControllerHapticProfiles { get; }
 ```
 
 #### RightControllers
@@ -409,6 +944,196 @@ public IEnumerable<VelocityTracker> RightControllerVelocityTrackers { get; }
 
 ### Methods
 
+#### BeginHapticProcessOnLeftController()
+
+Begins the haptic process on the Left Controller using the main HapticProcess.
+
+##### Declaration
+
+```
+public virtual void BeginHapticProcessOnLeftController()
+```
+
+#### BeginHapticProcessOnLeftController(Int32)
+
+Begins a haptic process on the Left Controller using the given profile.
+
+##### Declaration
+
+```
+public virtual void BeginHapticProcessOnLeftController(int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | profileIndex | The index of the haptic profile to use. |
+
+#### BeginHapticProcessOnRightController()
+
+Begins the haptic process on the Right Controller using the main HapticProcess.
+
+##### Declaration
+
+```
+public virtual void BeginHapticProcessOnRightController()
+```
+
+#### BeginHapticProcessOnRightController(Int32)
+
+Begins a haptic process on the Right Controller using the given profile.
+
+##### Declaration
+
+```
+public virtual void BeginHapticProcessOnRightController(int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | profileIndex | The index of the haptic profile to use. |
+
+#### BeginHapticProfile(HapticProcessObservableList, Int32)
+
+Begins the haptic process for the specified profile.
+
+##### Declaration
+
+```
+protected virtual HapticProcess BeginHapticProfile(HapticProcessObservableList processes, int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| HapticProcessObservableList | processes | The processes to begin. |
+| System.Int32 | profileIndex | The index of the process to use. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| HapticProcess | The haptic process being accessed. |
+
+#### CancelActiveHapticProfileOnLeftController()
+
+Cancels the haptic process currently running on the Left Controller for the current haptic profile.
+
+##### Declaration
+
+```
+public virtual void CancelActiveHapticProfileOnLeftController()
+```
+
+#### CancelActiveHapticProfileOnRightController()
+
+Cancels the haptic process currently running on the Right Controller for the current haptic profile.
+
+##### Declaration
+
+```
+public virtual void CancelActiveHapticProfileOnRightController()
+```
+
+#### CancelAllHapticsOnLeftController()
+
+Cancels all haptic process currently running on the Left Controller.
+
+##### Declaration
+
+```
+public virtual void CancelAllHapticsOnLeftController()
+```
+
+#### CancelAllHapticsOnRightController()
+
+Cancels all haptic process currently running on the Right Controller.
+
+##### Declaration
+
+```
+public virtual void CancelAllHapticsOnRightController()
+```
+
+#### CancelHapticProcessOnLeftController()
+
+Cancels any haptic process currently running on the Left Controller using the main HapticProcess.
+
+##### Declaration
+
+```
+public virtual void CancelHapticProcessOnLeftController()
+```
+
+#### CancelHapticProcessOnLeftController(Int32)
+
+Cancels the haptic process currently running on the Left Controller for the given profile.
+
+##### Declaration
+
+```
+public virtual void CancelHapticProcessOnLeftController(int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | profileIndex | The index of the haptic profile to cancel. |
+
+#### CancelHapticProcessOnRightController()
+
+Cancels any haptic process currently running on the Right Controller using the main HapticProcess.
+
+##### Declaration
+
+```
+public virtual void CancelHapticProcessOnRightController()
+```
+
+#### CancelHapticProcessOnRightController(Int32)
+
+Cancels the haptic process currently running on the Right Controller for the given profile.
+
+##### Declaration
+
+```
+public virtual void CancelHapticProcessOnRightController(int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | profileIndex | The index of the haptic profile to cancel. |
+
+#### CancelHapticProfile(HapticProcessObservableList, Int32)
+
+Cancels the haptic process for the specified profile.
+
+##### Declaration
+
+```
+protected virtual HapticProcess CancelHapticProfile(HapticProcessObservableList processes, int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| HapticProcessObservableList | processes | The processes to cancel. |
+| System.Int32 | profileIndex | The index of the process to use. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| HapticProcess | The haptic process being accessed. |
+
 #### GetFirstActiveCamera(IEnumerable<Camera>)
 
 Gets the first active Camera found in the given collection.
@@ -430,6 +1155,50 @@ protected virtual Camera GetFirstActiveCamera(IEnumerable<Camera> collection)
 | Type | Description |
 | --- | --- |
 | Camera | The found first active element in the collection. |
+
+#### GetFirstActiveDeviceRecord(IEnumerable<DeviceDetailsRecord>)
+
+Gets the first active DeviceDetailsRecord found in the given collection.
+
+##### Declaration
+
+```
+protected virtual DeviceDetailsRecord GetFirstActiveDeviceRecord(IEnumerable<DeviceDetailsRecord> collection)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Collections.Generic.IEnumerable<DeviceDetailsRecord\> | collection | The collection to look for the first active in. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| DeviceDetailsRecord | The found first active element in the collection. |
+
+#### GetFirstActiveDominantControllerObserver(IEnumerable<DominantControllerObserver>)
+
+Gets the first active DominantControllerObserver found in the given collection.
+
+##### Declaration
+
+```
+protected virtual DominantControllerObserver GetFirstActiveDominantControllerObserver(IEnumerable<DominantControllerObserver> collection)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Collections.Generic.IEnumerable<DominantControllerObserver\> | collection | The collection to look for the first active in. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| DominantControllerObserver | The found first active element in the collection. |
 
 #### GetFirstActiveGameObject(IEnumerable<GameObject>)
 
@@ -475,6 +1244,28 @@ protected virtual HapticProcess GetFirstActiveHapticProcess(IEnumerable<HapticPr
 | --- | --- |
 | HapticProcess | The found first active element in the collection. |
 
+#### GetFirstActiveHapticProfile(IEnumerable<HapticProcessObservableList>)
+
+Gets the first active profile found in the given haptic profile collection.
+
+##### Declaration
+
+```
+protected virtual HapticProcessObservableList GetFirstActiveHapticProfile(IEnumerable<HapticProcessObservableList> collection)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Collections.Generic.IEnumerable<HapticProcessObservableList\> | collection | The collection to look for the first active in. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| HapticProcessObservableList | The found first active profile collection in the collection. |
+
 #### GetFirstActiveLinkedAliasAssociationCollection(IEnumerable<LinkedAliasAssociationCollection>)
 
 Gets the first active LinkedAliasAssociationCollection found in the given collection.
@@ -518,6 +1309,29 @@ protected virtual VelocityTracker GetFirstActiveVelocityTracker(IEnumerable<Velo
 | Type | Description |
 | --- | --- |
 | VelocityTracker | The found first active element in the collection. |
+
+#### IsValidHapticProfile(HapticProcessObservableList, Int32)
+
+Determines whether the haptic profile is valid for the given index.
+
+##### Declaration
+
+```
+protected virtual bool IsValidHapticProfile(HapticProcessObservableList processes, int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| HapticProcessObservableList | processes | The processes to check. |
+| System.Int32 | profileIndex | The index of the process to check validity on. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the given index is a valid profile. |
 
 #### OnAfterCameraRigsChange()
 
@@ -632,46 +1446,111 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Fields]: #Fields
+[DominantControllerIsChanging]: #DominantControllerIsChanging
+[HeadsetBatteryChargeStatusChanged]: #HeadsetBatteryChargeStatusChanged
+[HeadsetConnectionStatusChanged]: #HeadsetConnectionStatusChanged
 [HeadsetTrackingBegun]: #HeadsetTrackingBegun
+[HeadsetTrackingTypeChanged]: #HeadsetTrackingTypeChanged
+[LeftControllerBatteryChargeStatusChanged]: #LeftControllerBatteryChargeStatusChanged
+[LeftControllerConnectionStatusChanged]: #LeftControllerConnectionStatusChanged
 [LeftControllerTrackingBegun]: #LeftControllerTrackingBegun
+[LeftControllerTrackingTypeChanged]: #LeftControllerTrackingTypeChanged
+[RightControllerBatteryChargeStatusChanged]: #RightControllerBatteryChargeStatusChanged
+[RightControllerConnectionStatusChanged]: #RightControllerConnectionStatusChanged
 [RightControllerTrackingBegun]: #RightControllerTrackingBegun
+[RightControllerTrackingTypeChanged]: #RightControllerTrackingTypeChanged
 [TrackedAliasChanged]: #TrackedAliasChanged
 [Properties]: #Properties
+[ActiveDominantControllerNode]: #ActiveDominantControllerNode
+[ActiveDominantControllerObserver]: #ActiveDominantControllerObserver
+[ActiveDominantControllerRecord]: #ActiveDominantControllerRecord
 [ActiveHeadset]: #ActiveHeadset
+[ActiveHeadsetBatteryChargeStatus]: #ActiveHeadsetBatteryChargeStatus
+[ActiveHeadsetBatteryLevel]: #ActiveHeadsetBatteryLevel
 [ActiveHeadsetCamera]: #ActiveHeadsetCamera
+[ActiveHeadsetDetails]: #ActiveHeadsetDetails
+[ActiveHeadsetIsConnected]: #ActiveHeadsetIsConnected
+[ActiveHeadsetManufacturer]: #ActiveHeadsetManufacturer
+[ActiveHeadsetModel]: #ActiveHeadsetModel
+[ActiveHeadsetTrackingHasBegun]: #ActiveHeadsetTrackingHasBegun
+[ActiveHeadsetTrackingType]: #ActiveHeadsetTrackingType
 [ActiveHeadsetVelocity]: #ActiveHeadsetVelocity
 [ActiveLeftController]: #ActiveLeftController
+[ActiveLeftControllerBatteryChargeStatus]: #ActiveLeftControllerBatteryChargeStatus
+[ActiveLeftControllerBatteryLevel]: #ActiveLeftControllerBatteryLevel
+[ActiveLeftControllerDetails]: #ActiveLeftControllerDetails
+[ActiveLeftControllerIsConnected]: #ActiveLeftControllerIsConnected
+[ActiveLeftControllerManufacturer]: #ActiveLeftControllerManufacturer
+[ActiveLeftControllerModel]: #ActiveLeftControllerModel
+[ActiveLeftControllerTrackingHasBegun]: #ActiveLeftControllerTrackingHasBegun
+[ActiveLeftControllerTrackingType]: #ActiveLeftControllerTrackingType
 [ActiveLeftControllerVelocity]: #ActiveLeftControllerVelocity
 [ActiveLeftHapticProcess]: #ActiveLeftHapticProcess
+[ActiveLeftHapticProfile]: #ActiveLeftHapticProfile
+[ActiveLeftHapticProfiles]: #ActiveLeftHapticProfiles
 [ActiveLinkedAliasAssociation]: #ActiveLinkedAliasAssociation
 [ActivePlayArea]: #ActivePlayArea
 [ActiveRightController]: #ActiveRightController
+[ActiveRightControllerBatteryChargeStatus]: #ActiveRightControllerBatteryChargeStatus
+[ActiveRightControllerBatteryLevel]: #ActiveRightControllerBatteryLevel
+[ActiveRightControllerDetails]: #ActiveRightControllerDetails
+[ActiveRightControllerIsConnected]: #ActiveRightControllerIsConnected
+[ActiveRightControllerManufacturer]: #ActiveRightControllerManufacturer
+[ActiveRightControllerModel]: #ActiveRightControllerModel
+[ActiveRightControllerTrackingHasBegun]: #ActiveRightControllerTrackingHasBegun
+[ActiveRightControllerTrackingType]: #ActiveRightControllerTrackingType
 [ActiveRightControllerVelocity]: #ActiveRightControllerVelocity
 [ActiveRightHapticProcess]: #ActiveRightHapticProcess
+[ActiveRightHapticProfile]: #ActiveRightHapticProfile
+[ActiveRightHapticProfiles]: #ActiveRightHapticProfiles
 [CameraRigs]: #CameraRigs
 [Configuration]: #Configuration
+[DominantControllerObservers]: #DominantControllerObservers
 [HeadsetAlias]: #HeadsetAlias
 [HeadsetCameras]: #HeadsetCameras
+[HeadsetDeviceDetailRecords]: #HeadsetDeviceDetailRecords
 [HeadsetOriginAlias]: #HeadsetOriginAlias
 [Headsets]: #Headsets
 [HeadsetSupplementCameras]: #HeadsetSupplementCameras
 [HeadsetVelocityTrackers]: #HeadsetVelocityTrackers
 [LeftControllerAlias]: #LeftControllerAlias
+[LeftControllerDeviceDetailRecords]: #LeftControllerDeviceDetailRecords
 [LeftControllerHapticProcesses]: #LeftControllerHapticProcesses
+[LeftControllerHapticProfiles]: #LeftControllerHapticProfiles
 [LeftControllers]: #LeftControllers
 [LeftControllerVelocityTrackers]: #LeftControllerVelocityTrackers
 [PlayAreaAlias]: #PlayAreaAlias
 [PlayAreas]: #PlayAreas
 [RightControllerAlias]: #RightControllerAlias
+[RightControllerDeviceDetailRecords]: #RightControllerDeviceDetailRecords
 [RightControllerHapticProcesses]: #RightControllerHapticProcesses
+[RightControllerHapticProfiles]: #RightControllerHapticProfiles
 [RightControllers]: #RightControllers
 [RightControllerVelocityTrackers]: #RightControllerVelocityTrackers
 [Methods]: #Methods
+[BeginHapticProcessOnLeftController()]: #BeginHapticProcessOnLeftController
+[BeginHapticProcessOnLeftController(Int32)]: #BeginHapticProcessOnLeftControllerInt32
+[BeginHapticProcessOnRightController()]: #BeginHapticProcessOnRightController
+[BeginHapticProcessOnRightController(Int32)]: #BeginHapticProcessOnRightControllerInt32
+[BeginHapticProfile(HapticProcessObservableList, Int32)]: #BeginHapticProfileHapticProcessObservableList-Int32
+[CancelActiveHapticProfileOnLeftController()]: #CancelActiveHapticProfileOnLeftController
+[CancelActiveHapticProfileOnRightController()]: #CancelActiveHapticProfileOnRightController
+[CancelAllHapticsOnLeftController()]: #CancelAllHapticsOnLeftController
+[CancelAllHapticsOnRightController()]: #CancelAllHapticsOnRightController
+[CancelHapticProcessOnLeftController()]: #CancelHapticProcessOnLeftController
+[CancelHapticProcessOnLeftController(Int32)]: #CancelHapticProcessOnLeftControllerInt32
+[CancelHapticProcessOnRightController()]: #CancelHapticProcessOnRightController
+[CancelHapticProcessOnRightController(Int32)]: #CancelHapticProcessOnRightControllerInt32
+[CancelHapticProfile(HapticProcessObservableList, Int32)]: #CancelHapticProfileHapticProcessObservableList-Int32
 [GetFirstActiveCamera(IEnumerable<Camera>)]: #GetFirstActiveCameraIEnumerable<Camera>
+[GetFirstActiveDeviceRecord(IEnumerable<DeviceDetailsRecord>)]: #GetFirstActiveDeviceRecordIEnumerable<DeviceDetailsRecord>
+[GetFirstActiveDominantControllerObserver(IEnumerable<DominantControllerObserver>)]: #GetFirstActiveDominantControllerObserverIEnumerable<DominantControllerObserver>
 [GetFirstActiveGameObject(IEnumerable<GameObject>)]: #GetFirstActiveGameObjectIEnumerable<GameObject>
 [GetFirstActiveHapticProcess(IEnumerable<HapticProcess>)]: #GetFirstActiveHapticProcessIEnumerable<HapticProcess>
+[GetFirstActiveHapticProfile(IEnumerable<HapticProcessObservableList>)]: #GetFirstActiveHapticProfileIEnumerable<HapticProcessObservableList>
 [GetFirstActiveLinkedAliasAssociationCollection(IEnumerable<LinkedAliasAssociationCollection>)]: #GetFirstActiveLinkedAliasAssociationCollectionIEnumerable<LinkedAliasAssociationCollection>
 [GetFirstActiveVelocityTracker(IEnumerable<VelocityTracker>)]: #GetFirstActiveVelocityTrackerIEnumerable<VelocityTracker>
+[IsValidHapticProfile(HapticProcessObservableList, Int32)]: #IsValidHapticProfileHapticProcessObservableList-Int32
 [OnAfterCameraRigsChange()]: #OnAfterCameraRigsChange
 [OnBeforeCameraRigsChange()]: #OnBeforeCameraRigsChange
 [OnCameraRigAdded(LinkedAliasAssociationCollection)]: #OnCameraRigAddedLinkedAliasAssociationCollection

--- a/Runtime/Prefabs/CameraRigs.TrackedAlias.prefab
+++ b/Runtime/Prefabs/CameraRigs.TrackedAlias.prefab
@@ -43,17 +43,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1b421ec2455cf9c479d63ce5c4fbe83c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  applyOffset: 1
   Premodified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Modified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  applyOffset: 1
+  applyModificationOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
 --- !u!1 &1133984005875406
 GameObject:
   m_ObjectHideFlags: 0
@@ -106,13 +106,9 @@ MonoBehaviour:
   Premodified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Modified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!1 &1140323171015104
 GameObject:
   m_ObjectHideFlags: 0
@@ -171,46 +167,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7a6b6179884db4f45985375ba8170f77, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.UnityObjectObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &1287509762966930
@@ -256,112 +239,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e2fed5d5fca45c4ab790523ce36160d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  applyOffset: 1
   Premodified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Modified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!1 &1320394306740216
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4575540592932172}
-  - component: {fileID: 114370656474179720}
-  - component: {fileID: 114210250122447072}
-  m_Layer: 0
-  m_Name: HeadsetPositionalChange
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4575540592932172
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1320394306740216}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4635924196392176}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114370656474179720
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1320394306740216}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source:
-    field: {fileID: 114210250122447072}
-  onlyProcessOnActiveAndEnabled: 1
-  interval: 0
---- !u!114 &114210250122447072
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1320394306740216}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f6e5bdd7c9c796d45b83b486c20fdec4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source: {fileID: 1756652776302202}
-  target: {fileID: 1756652776302202}
-  distanceThreshold: 0.001
-  ThresholdExceeded:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1320394306740216}
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 114148444839838400}
-        m_MethodName: NotifyHeadsetTrackingBegun
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: Zinnia.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  ThresholdResumed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  applyOffset: 1
+  applyModificationOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
 --- !u!1 &1390416002302802
 GameObject:
   m_ObjectHideFlags: 0
@@ -428,8 +316,6 @@ MonoBehaviour:
   ActiveSourceChanging:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 8715506455101722365}
   sourceValidity:
@@ -442,13 +328,9 @@ MonoBehaviour:
   Preprocessed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Processed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114394881288804734
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -475,39 +357,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoRejectStates: -1
---- !u!1 &1419536416562970
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4635924196392176}
-  m_Layer: 0
-  m_Name: ElementPositionalChange
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4635924196392176
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1419536416562970}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 4575540592932172}
-  - {fileID: 4376484404237658}
-  - {fileID: 4927830238588236}
-  m_Father: {fileID: 4128381786250224}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1436298999132832
 GameObject:
   m_ObjectHideFlags: 0
@@ -538,7 +387,6 @@ Transform:
   m_Children:
   - {fileID: 4604216046211440}
   - {fileID: 4710110883841260}
-  - {fileID: 4635924196392176}
   - {fileID: 8190876674237217151}
   m_Father: {fileID: 4419020640412130}
   m_RootOrder: 1
@@ -631,8 +479,6 @@ MonoBehaviour:
   ActiveSourceChanging:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 8386388317214558777}
   sourceValidity:
@@ -645,13 +491,9 @@ MonoBehaviour:
   Preprocessed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Processed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &1485454202899344
 GameObject:
   m_ObjectHideFlags: 0
@@ -710,51 +552,35 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
-  - {fileID: 114370656474179720}
-  - {fileID: 114644331804853310}
-  - {fileID: 114507909976065154}
   - {fileID: 114463072076221852}
   - {fileID: 114838382803823290}
   - {fileID: 114439853570832652}
@@ -809,24 +635,45 @@ MonoBehaviour:
   TrackedAliasChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Tilia.CameraRigs.TrackedAlias.TrackedAliasFacade+LinkedAliasAssociationCollectionUnityEvent,
-      Tilia.CameraRigs.TrackedAlias.Unity.Runtime, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
+  DominantControllerIsChanging:
+    m_PersistentCalls:
+      m_Calls: []
   HeadsetTrackingBegun:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+  HeadsetConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  HeadsetTrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  HeadsetBatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
   LeftControllerTrackingBegun:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+  LeftControllerConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  LeftControllerTrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  LeftControllerBatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
   RightControllerTrackingBegun:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+  RightControllerConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  RightControllerTrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  RightControllerBatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
   configuration: {fileID: 114148444839838400}
 --- !u!1 &1673389523159584
 GameObject:
@@ -863,101 +710,6 @@ Transform:
   m_Father: {fileID: 4419020640412130}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1677192783888292
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4376484404237658}
-  - component: {fileID: 114644331804853310}
-  - component: {fileID: 114512765214697388}
-  m_Layer: 0
-  m_Name: LeftControllerPositionalChange
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4376484404237658
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1677192783888292}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4635924196392176}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114644331804853310
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1677192783888292}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source:
-    field: {fileID: 114512765214697388}
-  onlyProcessOnActiveAndEnabled: 1
-  interval: 0
---- !u!114 &114512765214697388
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1677192783888292}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f6e5bdd7c9c796d45b83b486c20fdec4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source: {fileID: 1883915491596086}
-  target: {fileID: 1883915491596086}
-  distanceThreshold: 0.001
-  ThresholdExceeded:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1677192783888292}
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 114148444839838400}
-        m_MethodName: NotifyLeftControllerTrackingBegun
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: Zinnia.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  ThresholdResumed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!1 &1756652776302202
 GameObject:
   m_ObjectHideFlags: 0
@@ -1035,8 +787,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 8623578196889787470}
   sourceValidity:
@@ -1049,13 +799,9 @@ MonoBehaviour:
   Preprocessed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Processed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114855179307605532
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1125,112 +871,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82e1be200ae387d4c95c60842582358d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  applyOffset: 1
   Premodified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Modified:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!1 &1881132033643546
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4927830238588236}
-  - component: {fileID: 114507909976065154}
-  - component: {fileID: 114963507534984794}
-  m_Layer: 0
-  m_Name: RightControllerPositionalChange
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4927830238588236
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1881132033643546}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4635924196392176}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114507909976065154
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1881132033643546}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source:
-    field: {fileID: 114963507534984794}
-  onlyProcessOnActiveAndEnabled: 1
-  interval: 0
---- !u!114 &114963507534984794
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1881132033643546}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f6e5bdd7c9c796d45b83b486c20fdec4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source: {fileID: 1390416002302802}
-  target: {fileID: 1390416002302802}
-  distanceThreshold: 0.001
-  ThresholdExceeded:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1881132033643546}
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 114148444839838400}
-        m_MethodName: NotifyRightControllerTrackingBegun
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: Zinnia.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  ThresholdResumed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  applyOffset: 1
+  applyModificationOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
 --- !u!1 &1883915491596086
 GameObject:
   m_ObjectHideFlags: 0
@@ -1297,8 +948,6 @@ MonoBehaviour:
   ActiveSourceChanging:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 1383084746341599450}
   sourceValidity:
@@ -1311,13 +960,9 @@ MonoBehaviour:
   Preprocessed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Processed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114916227885696116
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1387,46 +1032,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &265702878875880929
@@ -1504,46 +1136,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74e0cf63a9a8d89409876f85cae7ae7a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &1048701673657469624
@@ -1589,46 +1208,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 1756652776302202}
@@ -1738,46 +1344,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 1390416002302802}
@@ -1845,8 +1438,6 @@ MonoBehaviour:
   ActiveSourceChanging:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Process.Component.GameObjectSourceTargetProcessor+GameObjectUnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ceaseAfterFirstSourceProcessed: 1
   sources: {fileID: 5564063951778842142}
   sourceValidity:
@@ -1859,13 +1450,9 @@ MonoBehaviour:
   Preprocessed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Processed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &2303780985125294565
 GameObject:
   m_ObjectHideFlags: 0
@@ -1909,46 +1496,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &2565031879320966894
@@ -1994,46 +1568,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 1458957959020712}
@@ -2099,7 +1660,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4128381786250224}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &960702652617744129
 MonoBehaviour:
@@ -2113,46 +1674,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e8c5b75d4472e54986eae4cf8048212, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.CameraRig.Collection.LinkedAliasAssociationCollectionObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.CameraRig.Collection.LinkedAliasAssociationCollectionObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.CameraRig.Collection.LinkedAliasAssociationCollectionObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.CameraRig.Collection.LinkedAliasAssociationCollectionObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.CameraRig.Collection.LinkedAliasAssociationCollectionObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.CameraRig.Collection.LinkedAliasAssociationCollectionObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &3057444867599970114
@@ -2229,46 +1777,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &3459563734610350754
@@ -2314,46 +1849,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 2052708542540457377}
@@ -2400,46 +1922,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &4554267983074023489
@@ -2485,46 +1994,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 1883915491596086}
@@ -2571,46 +2067,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &5891404491509266472
@@ -2656,46 +2139,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74e0cf63a9a8d89409876f85cae7ae7a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &6298408938876280095
@@ -2774,46 +2244,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &6656668105393937030
@@ -2892,46 +2349,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &7217236753381430914
@@ -2977,46 +2421,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &7367337954493963990
@@ -3127,46 +2558,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74e0cf63a9a8d89409876f85cae7ae7a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Velocity.Collection.VelocityTrackerObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &8767623225079506361
@@ -3212,46 +2630,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements: []
 --- !u!1 &8893082356054646536
@@ -3297,46 +2702,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Data.Collection.List.GameObjectObservableList+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 1756652776302202}

--- a/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
@@ -3,9 +3,11 @@
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using UnityEngine.Events;
     using Zinnia.Data.Attribute;
     using Zinnia.Extension;
     using Zinnia.Rule;
+    using Zinnia.Tracking.CameraRig;
     using Zinnia.Tracking.Follow;
     using Zinnia.Tracking.Velocity;
 
@@ -96,6 +98,129 @@
         public bool IncludeHeadsetSupplementCameras { get; set; } = true;
         #endregion
 
+        #region Main Data Cache
+        /// <summary>
+        /// The current cached Linked Alias Association Collection.
+        /// </summary>
+        protected LinkedAliasAssociationCollection cachedLinkedAlias;
+        /// <summary>
+        /// The current cached dominant controller.
+        /// </summary>
+        protected DeviceDetailsRecord cachedCurrentDominantController;
+        /// <summary>
+        /// The event handler to run when the bubbled dominant controller is changing is raised.
+        /// </summary>
+        protected UnityAction<DeviceDetailsRecord> DominantControllerIsChangingEventHandler;
+        #endregion
+
+        #region Headset Data Cache
+        /// <summary>
+        /// The current cached headset tracking begun status.
+        /// </summary>
+        protected bool cachedHeadsetTrackingBegun;
+        /// <summary>
+        /// The current cached headset connection status.
+        /// </summary>
+        protected bool cachedHeadsetConnectionStatus;
+        /// <summary>
+        /// The current cached headset tracking type.
+        /// </summary>
+        protected DeviceDetailsRecord.SpatialTrackingType cachedHeadsetSpatialTrackingType;
+        /// <summary>
+        /// The current cached headset battery charge status.
+        /// </summary>
+        protected BatteryStatus cachedHeadsetBatteryChargeStatus;
+
+        /// <summary>
+        /// The event handler to run when the bubbled headset event for tracking begun is raised.
+        /// </summary>
+        protected UnityAction HeadsetTrackingBegunEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled headset event for connection changed is raised.
+        /// </summary>
+        protected UnityAction<bool> HeadsetConnectionChangedEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled headset event for tracking type changed is raised.
+        /// </summary>
+        protected UnityAction<DeviceDetailsRecord.SpatialTrackingType> HeadsetTrackingTypeChangedEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled headset event for battery charge status changed is raised.
+        /// </summary>
+        protected UnityAction<BatteryStatus> HeadsetBatteryChargeStatusChangedEventHandler;
+        #endregion
+
+        #region Left Controller Data Cache
+        /// <summary>
+        /// The current cached left controller tracking begun status.
+        /// </summary>
+        protected bool cachedLeftControllerTrackingBegun;
+        /// <summary>
+        /// The current cached left controller connection status.
+        /// </summary>
+        protected bool cachedLeftControllerConnectionStatus;
+        /// <summary>
+        /// The current cached left controller tracking type.
+        /// </summary>
+        protected DeviceDetailsRecord.SpatialTrackingType cachedLeftControllerSpatialTrackingType;
+        /// <summary>
+        /// The current cached left controller battery charge status.
+        /// </summary>
+        protected BatteryStatus cachedLeftControllerBatteryChargeStatus;
+
+        /// <summary>
+        /// The event handler to run when the bubbled left controller event for tracking begun is raised.
+        /// </summary>
+        protected UnityAction LeftControllerTrackingBegunEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled left controller event for connection changed is raised.
+        /// </summary>
+        protected UnityAction<bool> LeftControllerConnectionChangedEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled left controller event for tracking type changed is raised.
+        /// </summary>
+        protected UnityAction<DeviceDetailsRecord.SpatialTrackingType> LeftControllerTrackingTypeChangedEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled left controller event for battery charge status changed is raised.
+        /// </summary>
+        protected UnityAction<BatteryStatus> LeftControllerBatteryChargeStatusChangedEventHandler;
+        #endregion
+
+        #region Right Controller Data Cache
+        /// <summary>
+        /// The current cached right controller tracking begun status.
+        /// </summary>
+        protected bool cachedRightControllerTrackingBegun;
+        /// <summary>
+        /// The current cached right controller connection status.
+        /// </summary>
+        protected bool cachedRightControllerConnectionStatus;
+        /// <summary>
+        /// The current cached right controller tracking type.
+        /// </summary>
+        protected DeviceDetailsRecord.SpatialTrackingType cachedRightControllerSpatialTrackingType;
+        /// <summary>
+        /// The current cached right controller battery charge status.
+        /// </summary>
+        protected BatteryStatus cachedRightControllerBatteryChargeStatus;
+
+        /// <summary>
+        /// The event handler to run when the bubbled right controller event for tracking begun is raised.
+        /// </summary>
+        protected UnityAction RightControllerTrackingBegunEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled right controller event for connection changed is raised.
+        /// </summary>
+        protected UnityAction<bool> RightControllerConnectionChangedEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled right controller event for tracking type changed is raised.
+        /// </summary>
+        protected UnityAction<DeviceDetailsRecord.SpatialTrackingType> RightControllerTrackingTypeChangedEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled right controller event for battery charge status changed is raised.
+        /// </summary>
+        protected UnityAction<BatteryStatus> RightControllerBatteryChargeStatusChangedEventHandler;
+        #endregion
+
         /// <summary>
         /// Sets up the TrackedAlias prefab with the specified settings.
         /// </summary>
@@ -161,8 +286,14 @@
         /// <summary>
         /// Notifies when the tracked alias source has changed.
         /// </summary>
-        public virtual void NotifyTrackedAliasChanged(GameObject newAlias)
+        public virtual void NotifyTrackedAliasChanged(GameObject _)
         {
+            cachedHeadsetTrackingBegun = false;
+            cachedLeftControllerTrackingBegun = false;
+            cachedRightControllerTrackingBegun = false;
+
+            SubscribeToDetailsEvents();
+            CheckExistingEventStatus();
             Facade.TrackedAliasChanged?.Invoke(Facade.ActiveLinkedAliasAssociation);
         }
 
@@ -193,6 +324,215 @@
         protected virtual void OnEnable()
         {
             SetUpCameraRigsConfiguration();
+        }
+
+        /// <summary>
+        /// Checks if the two given values equal and raises the given event with the relevant payload if they are not.
+        /// </summary>
+        /// <typeparam name="TValue">The variable type to check equality with.</typeparam>
+        /// <typeparam name="TEvent">The <see cref="UnityEvent"/> type to raise.</typeparam>
+        /// <param name="comparer">The source value to compare from.</param>
+        /// <param name="comparator">The target value to compare with.</param>
+        /// <param name="output">The event to raise if the two values are not equal.</param>
+        protected virtual void CheckAndRaiseEventWithPayload<TValue, TEvent>(ref TValue comparer, TValue comparator, TEvent output) where TEvent : UnityEvent<TValue>, new()
+        {
+            if (comparator == null)
+            {
+                return;
+            }
+
+            if (!comparator.Equals(comparer))
+            {
+                output?.Invoke(comparator);
+            }
+
+            comparer = comparator;
+        }
+
+        /// <summary>
+        /// Checks if the two given values equal and raises the given event if they are not.
+        /// </summary>
+        /// <typeparam name="TValue">The variable type to check equality with.</typeparam>
+        /// <typeparam name="TEvent">The <see cref="UnityEvent"/> type to raise.</typeparam>
+        /// <param name="comparer">The source value to compare from.</param>
+        /// <param name="comparator">The target value to compare with.</param>
+        /// <param name="output">The event to raise if the two values are not equal.</param>
+        protected virtual void CheckAndRaiseEventWithoutPayload<TValue, TEvent>(ref TValue comparer, TValue comparator, TEvent output) where TEvent : UnityEvent, new()
+        {
+            if (comparator == null)
+            {
+                return;
+            }
+
+            if (!comparator.Equals(comparer))
+            {
+                output?.Invoke();
+            }
+
+            comparer = comparator;
+        }
+
+        /// <summary>
+        /// Caches the given new value and raises the given event with the new value as the payload.
+        /// </summary>
+        /// <typeparam name="TValue">The variable type of the given values.</typeparam>
+        /// <typeparam name="TEvent">The <see cref="UnityEvent"/> type to raise.</typeparam>
+        /// <param name="newValue">The new value to cache.</param>
+        /// <param name="cachedValue">The existing cached value.</param>
+        /// <param name="output">The event to raise.</param>
+        protected virtual void CacheAndRaiseEventWithPayload<TValue, TEvent>(TValue newValue, ref TValue cachedValue, TEvent output) where TEvent : UnityEvent<TValue>, new()
+        {
+            cachedValue = newValue;
+            output?.Invoke(newValue);
+        }
+
+        /// <summary>
+        /// Caches the given new value and raises the given event.
+        /// </summary>
+        /// <typeparam name="TValue">The variable type of the given values.</typeparam>
+        /// <typeparam name="TEvent">The <see cref="UnityEvent"/> type to raise.</typeparam>
+        /// <param name="newValue">The new value to cache.</param>
+        /// <param name="cachedValue">The existing cached value.</param>
+        /// <param name="output">The event to raise.</param>
+        protected virtual void CacheAndRaiseEventWithoutPayload<TValue, TEvent>(TValue newValue, ref TValue cachedValue, TEvent output) where TEvent : UnityEvent, new()
+        {
+            cachedValue = newValue;
+            output?.Invoke();
+        }
+
+        /// <summary>
+        /// Check the existing status of the event values and raise a new event if it has changed.
+        /// </summary>
+        protected virtual void CheckExistingEventStatus()
+        {
+            if (Facade == null)
+            {
+                return;
+            }
+
+            if (Facade.ActiveDominantControllerRecord != null)
+            {
+                CheckAndRaiseEventWithPayload(ref cachedCurrentDominantController, Facade.ActiveDominantControllerRecord, Facade.DominantControllerIsChanging);
+            }
+
+            if (Facade.ActiveHeadsetDetails != null)
+            {
+                CheckAndRaiseEventWithoutPayload(ref cachedHeadsetTrackingBegun, Facade.ActiveHeadsetTrackingHasBegun, Facade.HeadsetTrackingBegun);
+                CheckAndRaiseEventWithPayload(ref cachedHeadsetConnectionStatus, Facade.ActiveHeadsetIsConnected, Facade.HeadsetConnectionStatusChanged);
+                CheckAndRaiseEventWithPayload(ref cachedHeadsetSpatialTrackingType, Facade.ActiveHeadsetTrackingType, Facade.HeadsetTrackingTypeChanged);
+                CheckAndRaiseEventWithPayload(ref cachedHeadsetBatteryChargeStatus, Facade.ActiveHeadsetBatteryChargeStatus, Facade.HeadsetBatteryChargeStatusChanged);
+            }
+
+            if (Facade.ActiveLeftControllerDetails != null)
+            {
+                CheckAndRaiseEventWithoutPayload(ref cachedLeftControllerTrackingBegun, Facade.ActiveLeftControllerTrackingHasBegun, Facade.LeftControllerTrackingBegun);
+                CheckAndRaiseEventWithPayload(ref cachedLeftControllerConnectionStatus, Facade.ActiveLeftControllerIsConnected, Facade.LeftControllerConnectionStatusChanged);
+                CheckAndRaiseEventWithPayload(ref cachedLeftControllerSpatialTrackingType, Facade.ActiveLeftControllerTrackingType, Facade.LeftControllerTrackingTypeChanged);
+                CheckAndRaiseEventWithPayload(ref cachedLeftControllerBatteryChargeStatus, Facade.ActiveLeftControllerBatteryChargeStatus, Facade.LeftControllerBatteryChargeStatusChanged);
+            }
+
+            if (Facade.ActiveRightControllerDetails != null)
+            {
+                CheckAndRaiseEventWithoutPayload(ref cachedRightControllerTrackingBegun, Facade.ActiveRightControllerTrackingHasBegun, Facade.RightControllerTrackingBegun);
+                CheckAndRaiseEventWithPayload(ref cachedRightControllerConnectionStatus, Facade.ActiveRightControllerIsConnected, Facade.RightControllerConnectionStatusChanged);
+                CheckAndRaiseEventWithPayload(ref cachedRightControllerSpatialTrackingType, Facade.ActiveRightControllerTrackingType, Facade.RightControllerTrackingTypeChanged);
+                CheckAndRaiseEventWithPayload(ref cachedRightControllerBatteryChargeStatus, Facade.ActiveRightControllerBatteryChargeStatus, Facade.RightControllerBatteryChargeStatusChanged);
+            }
+        }
+
+        /// <summary>
+        /// Subscribe to the events of each <see cref="DeviceDetailsRecord"/>.
+        /// </summary>
+        protected virtual void SubscribeToDetailsEvents()
+        {
+            if (cachedLinkedAlias != null && cachedLinkedAlias != Facade.ActiveLinkedAliasAssociation)
+            {
+                UnsubscribeToDetailsEvents();
+            }
+
+            if (Facade.ActiveLinkedAliasAssociation != null && Facade.ActiveLinkedAliasAssociation.DominantController != null)
+            {
+                DominantControllerIsChangingEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedCurrentDominantController, Facade.DominantControllerIsChanging);
+                Facade.ActiveLinkedAliasAssociation.DominantController.IsChanging.AddListener(DominantControllerIsChangingEventHandler);
+            }
+
+            if (Facade.ActiveLinkedAliasAssociation != null && Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails != null)
+            {
+                HeadsetTrackingBegunEventHandler = () => CacheAndRaiseEventWithoutPayload(true, ref cachedHeadsetTrackingBegun, Facade.HeadsetTrackingBegun);
+                HeadsetConnectionChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedHeadsetConnectionStatus, Facade.HeadsetConnectionStatusChanged);
+                HeadsetTrackingTypeChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedHeadsetSpatialTrackingType, Facade.HeadsetTrackingTypeChanged);
+                HeadsetBatteryChargeStatusChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedHeadsetBatteryChargeStatus, Facade.HeadsetBatteryChargeStatusChanged);
+
+                Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.TrackingBegun.AddListener(HeadsetTrackingBegunEventHandler);
+                Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.ConnectionStatusChanged.AddListener(HeadsetConnectionChangedEventHandler);
+                Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.TrackingTypeChanged.AddListener(HeadsetTrackingTypeChangedEventHandler);
+                Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.BatteryChargeStatusChanged.AddListener(HeadsetBatteryChargeStatusChangedEventHandler);
+            }
+
+            if (Facade.ActiveLinkedAliasAssociation != null && Facade.ActiveLinkedAliasAssociation.LeftControllerDeviceDetails != null)
+            {
+                LeftControllerTrackingBegunEventHandler = () => CacheAndRaiseEventWithoutPayload(true, ref cachedLeftControllerTrackingBegun, Facade.LeftControllerTrackingBegun);
+                LeftControllerConnectionChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedLeftControllerConnectionStatus, Facade.LeftControllerConnectionStatusChanged);
+                LeftControllerTrackingTypeChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedLeftControllerSpatialTrackingType, Facade.LeftControllerTrackingTypeChanged);
+                LeftControllerBatteryChargeStatusChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedLeftControllerBatteryChargeStatus, Facade.LeftControllerBatteryChargeStatusChanged);
+
+                Facade.ActiveLinkedAliasAssociation.LeftControllerDeviceDetails.TrackingBegun.AddListener(LeftControllerTrackingBegunEventHandler);
+                Facade.ActiveLinkedAliasAssociation.LeftControllerDeviceDetails.ConnectionStatusChanged.AddListener(LeftControllerConnectionChangedEventHandler);
+                Facade.ActiveLinkedAliasAssociation.LeftControllerDeviceDetails.TrackingTypeChanged.AddListener(LeftControllerTrackingTypeChangedEventHandler);
+                Facade.ActiveLinkedAliasAssociation.LeftControllerDeviceDetails.BatteryChargeStatusChanged.AddListener(LeftControllerBatteryChargeStatusChangedEventHandler);
+            }
+
+            if (Facade.ActiveLinkedAliasAssociation != null && Facade.ActiveLinkedAliasAssociation.RightControllerDeviceDetails != null)
+            {
+                RightControllerTrackingBegunEventHandler = () => CacheAndRaiseEventWithoutPayload(true, ref cachedRightControllerTrackingBegun, Facade.RightControllerTrackingBegun);
+                RightControllerConnectionChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedRightControllerConnectionStatus, Facade.RightControllerConnectionStatusChanged);
+                RightControllerTrackingTypeChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedRightControllerSpatialTrackingType, Facade.RightControllerTrackingTypeChanged);
+                RightControllerBatteryChargeStatusChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedRightControllerBatteryChargeStatus, Facade.RightControllerBatteryChargeStatusChanged);
+
+                Facade.ActiveLinkedAliasAssociation.RightControllerDeviceDetails.TrackingBegun.AddListener(RightControllerTrackingBegunEventHandler);
+                Facade.ActiveLinkedAliasAssociation.RightControllerDeviceDetails.ConnectionStatusChanged.AddListener(RightControllerConnectionChangedEventHandler);
+                Facade.ActiveLinkedAliasAssociation.RightControllerDeviceDetails.TrackingTypeChanged.AddListener(RightControllerTrackingTypeChangedEventHandler);
+                Facade.ActiveLinkedAliasAssociation.RightControllerDeviceDetails.BatteryChargeStatusChanged.AddListener(RightControllerBatteryChargeStatusChangedEventHandler);
+            }
+
+            cachedLinkedAlias = Facade.ActiveLinkedAliasAssociation;
+        }
+
+        /// <summary>
+        /// Unsubscribes from the events of each <see cref="DeviceDetailsRecord"/>.
+        /// </summary>
+        protected virtual void UnsubscribeToDetailsEvents()
+        {
+            if (cachedLinkedAlias != null && cachedLinkedAlias.DominantController != null)
+            {
+                cachedLinkedAlias.DominantController.IsChanging.RemoveListener(DominantControllerIsChangingEventHandler);
+            }
+
+            if (cachedLinkedAlias != null && cachedLinkedAlias.HeadsetDeviceDetails != null)
+            {
+                cachedLinkedAlias.HeadsetDeviceDetails.TrackingBegun.RemoveListener(HeadsetTrackingBegunEventHandler);
+                cachedLinkedAlias.HeadsetDeviceDetails.ConnectionStatusChanged.RemoveListener(HeadsetConnectionChangedEventHandler);
+                cachedLinkedAlias.HeadsetDeviceDetails.TrackingTypeChanged.RemoveListener(HeadsetTrackingTypeChangedEventHandler);
+                cachedLinkedAlias.HeadsetDeviceDetails.BatteryChargeStatusChanged.RemoveListener(HeadsetBatteryChargeStatusChangedEventHandler);
+            }
+
+            if (cachedLinkedAlias != null && cachedLinkedAlias.LeftControllerDeviceDetails != null)
+            {
+                cachedLinkedAlias.LeftControllerDeviceDetails.TrackingBegun.RemoveListener(LeftControllerTrackingBegunEventHandler);
+                cachedLinkedAlias.LeftControllerDeviceDetails.ConnectionStatusChanged.RemoveListener(LeftControllerConnectionChangedEventHandler);
+                cachedLinkedAlias.LeftControllerDeviceDetails.TrackingTypeChanged.RemoveListener(LeftControllerTrackingTypeChangedEventHandler);
+                cachedLinkedAlias.LeftControllerDeviceDetails.BatteryChargeStatusChanged.RemoveListener(LeftControllerBatteryChargeStatusChangedEventHandler);
+            }
+
+            if (cachedLinkedAlias != null && cachedLinkedAlias.RightControllerDeviceDetails != null)
+            {
+                cachedLinkedAlias.RightControllerDeviceDetails.TrackingBegun.RemoveListener(RightControllerTrackingBegunEventHandler);
+                cachedLinkedAlias.RightControllerDeviceDetails.ConnectionStatusChanged.RemoveListener(RightControllerConnectionChangedEventHandler);
+                cachedLinkedAlias.RightControllerDeviceDetails.TrackingTypeChanged.RemoveListener(RightControllerTrackingTypeChangedEventHandler);
+                cachedLinkedAlias.RightControllerDeviceDetails.BatteryChargeStatusChanged.RemoveListener(RightControllerBatteryChargeStatusChangedEventHandler);
+            }
+
+            cachedLinkedAlias = null;
         }
     }
 }

--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -7,6 +7,7 @@
     using System.Collections.Generic;
     using UnityEngine;
     using UnityEngine.Events;
+    using UnityEngine.XR;
     using Zinnia.Data.Attribute;
     using Zinnia.Haptics;
     using Zinnia.Haptics.Collection;
@@ -42,17 +43,69 @@
         [Header("Tracking Events")]
         public LinkedAliasAssociationCollectionUnityEvent TrackedAliasChanged = new LinkedAliasAssociationCollectionUnityEvent();
         /// <summary>
+        /// Emitted when the dominant controller is changing.
+        /// </summary>
+        public DominantControllerObserver.UnityEvent DominantControllerIsChanging = new DominantControllerObserver.UnityEvent();
+        #endregion
+
+        #region Headset Events
+        /// <summary>
         /// Emitted when the headset starts tracking for the first time.
         /// </summary>
+        [Header("Headset Events")]
         public UnityEvent HeadsetTrackingBegun = new UnityEvent();
+        /// <summary>
+        /// Emitted when the headset connection status changes.
+        /// </summary>
+        public DeviceDetailsRecord.BoolUnityEvent HeadsetConnectionStatusChanged = new DeviceDetailsRecord.BoolUnityEvent();
+        /// <summary>
+        /// Emitted when the headset tracking type changes.
+        /// </summary>
+        public DeviceDetailsRecord.SpatialTrackingTypeUnityEvent HeadsetTrackingTypeChanged = new DeviceDetailsRecord.SpatialTrackingTypeUnityEvent();
+        /// <summary>
+        /// Emitted when the headset battery charge status changes.
+        /// </summary>
+        public DeviceDetailsRecord.BatteryStatusUnityEvent HeadsetBatteryChargeStatusChanged = new DeviceDetailsRecord.BatteryStatusUnityEvent();
+        #endregion
+
+        #region Left Controller Events
         /// <summary>
         /// Emitted when the left controller starts tracking for the first time.
         /// </summary>
+        [Header("Left Controller Events")]
         public UnityEvent LeftControllerTrackingBegun = new UnityEvent();
+        /// <summary>
+        /// Emitted when the left controller connection status changes.
+        /// </summary>
+        public DeviceDetailsRecord.BoolUnityEvent LeftControllerConnectionStatusChanged = new DeviceDetailsRecord.BoolUnityEvent();
+        /// <summary>
+        /// Emitted when the left controller tracking type changes.
+        /// </summary>
+        public DeviceDetailsRecord.SpatialTrackingTypeUnityEvent LeftControllerTrackingTypeChanged = new DeviceDetailsRecord.SpatialTrackingTypeUnityEvent();
+        /// <summary>
+        /// Emitted when the left controller battery charge status changes.
+        /// </summary>
+        public DeviceDetailsRecord.BatteryStatusUnityEvent LeftControllerBatteryChargeStatusChanged = new DeviceDetailsRecord.BatteryStatusUnityEvent();
+        #endregion
+
+        #region Right Controller Events
         /// <summary>
         /// Emitted when the right controller starts tracking for the first time.
         /// </summary>
+        [Header("Right Controller Events")]
         public UnityEvent RightControllerTrackingBegun = new UnityEvent();
+        /// <summary>
+        /// Emitted when the right controller connection status changes.
+        /// </summary>
+        public DeviceDetailsRecord.BoolUnityEvent RightControllerConnectionStatusChanged = new DeviceDetailsRecord.BoolUnityEvent();
+        /// <summary>
+        /// Emitted when the right controller tracking type changes.
+        /// </summary>
+        public DeviceDetailsRecord.SpatialTrackingTypeUnityEvent RightControllerTrackingTypeChanged = new DeviceDetailsRecord.SpatialTrackingTypeUnityEvent();
+        /// <summary>
+        /// Emitted when the right controller battery charge status changes.
+        /// </summary>
+        public DeviceDetailsRecord.BatteryStatusUnityEvent RightControllerBatteryChargeStatusChanged = new DeviceDetailsRecord.BatteryStatusUnityEvent();
         #endregion
 
         #region Reference Settings
@@ -82,6 +135,50 @@
         /// </summary>
         public VelocityTracker ActiveHeadsetVelocity => GetFirstActiveVelocityTracker(HeadsetVelocityTrackers);
         /// <summary>
+        /// Retrieves the active Headset Detail Record that the TrackedAlias is using.
+        /// </summary>
+        public DeviceDetailsRecord ActiveHeadsetDetails => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords);
+        /// <summary>
+        /// Retrieves the active Headset Detail Tracking Begun status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveHeadsetTrackingHasBegun => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).TrackingHasBegun;
+        /// <summary>
+        /// Retrieves the active Headset Detail Is Connected status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveHeadsetIsConnected => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).IsConnected;
+        /// <summary>
+        /// Retrieves the active Headset Detail Manufacturer status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveHeadsetManufacturer => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).Manufacturer;
+        /// <summary>
+        /// Retrieves the active Headset Detail Model status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveHeadsetModel => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).Model;
+        /// <summary>
+        /// Retrieves the active Headset Detail Tracking Type status that the TrackedAlias is using.
+        /// </summary>
+        public DeviceDetailsRecord.SpatialTrackingType ActiveHeadsetTrackingType => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).TrackingType;
+        /// <summary>
+        /// Retrieves the active Headset Detail Battery Level status that the TrackedAlias is using.
+        /// </summary>
+        public float ActiveHeadsetBatteryLevel => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).BatteryLevel;
+        /// <summary>
+        /// Retrieves the active Headset Detail Battery Charge status that the TrackedAlias is using.
+        /// </summary>
+        public BatteryStatus ActiveHeadsetBatteryChargeStatus => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).BatteryChargeStatus;
+        /// <summary>
+        /// Retrieves the active Headset Detail Record that the TrackedAlias is using.
+        /// </summary>
+        public DominantControllerObserver ActiveDominantControllerObserver => GetFirstActiveDominantControllerObserver(DominantControllerObservers);
+        /// <summary>
+        /// Retrieves the dominant connected controller node.
+        /// </summary>
+        public XRNode ActiveDominantControllerNode => ActiveDominantControllerObserver != null ? ActiveDominantControllerObserver.DominantController : XRNode.Head;
+        /// <summary>
+        /// Retrieves the dominant connected controller node.
+        /// </summary>
+        public DeviceDetailsRecord ActiveDominantControllerRecord => ActiveDominantControllerObserver != null ? ActiveDominantControllerObserver.DominantControllerDetails : null;
+        /// <summary>
         /// Retrieves the active Left Controller that the TrackedAlias is using.
         /// </summary>
         public GameObject ActiveLeftController => GetFirstActiveGameObject(LeftControllers);
@@ -102,6 +199,38 @@
         /// </summary>
         public HapticProcess ActiveLeftHapticProfile { get; protected set; }
         /// <summary>
+        /// Retrieves the active LeftController Detail Record that the TrackedAlias is using.
+        /// </summary>
+        public DeviceDetailsRecord ActiveLeftControllerDetails => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords);
+        /// <summary>
+        /// Retrieves the active LeftController Detail Tracking Begun status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveLeftControllerTrackingHasBegun => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).TrackingHasBegun;
+        /// <summary>
+        /// Retrieves the active LeftController Detail Is Connected status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveLeftControllerIsConnected => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).IsConnected;
+        /// <summary>
+        /// Retrieves the active LeftController Detail Manufacturer status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveLeftControllerManufacturer => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).Manufacturer;
+        /// <summary>
+        /// Retrieves the active LeftController Detail Model status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveLeftControllerModel => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).Model;
+        /// <summary>
+        /// Retrieves the active LeftController Detail Tracking Type status that the TrackedAlias is using.
+        /// </summary>
+        public DeviceDetailsRecord.SpatialTrackingType ActiveLeftControllerTrackingType => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).TrackingType;
+        /// <summary>
+        /// Retrieves the active LeftController Detail Battery Level status that the TrackedAlias is using.
+        /// </summary>
+        public float ActiveLeftControllerBatteryLevel => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).BatteryLevel;
+        /// <summary>
+        /// Retrieves the active LeftController Detail Battery Charge status that the TrackedAlias is using.
+        /// </summary>
+        public BatteryStatus ActiveLeftControllerBatteryChargeStatus => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).BatteryChargeStatus;
+        /// <summary>
         /// Retrieves the active Right Controller that the TrackedAlias is using.
         /// </summary>
         public GameObject ActiveRightController => GetFirstActiveGameObject(RightControllers);
@@ -121,6 +250,38 @@
         /// Retrieves the active Right Controller Haptic Profile that has been most recently used.
         /// </summary>
         public HapticProcess ActiveRightHapticProfile { get; protected set; }
+        /// <summary>
+        /// Retrieves the active RightController Detail Record that the TrackedAlias is using.
+        /// </summary>
+        public DeviceDetailsRecord ActiveRightControllerDetails => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords);
+        /// <summary>
+        /// Retrieves the active RightController Detail Tracking Begun status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveRightControllerTrackingHasBegun => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).TrackingHasBegun;
+        /// <summary>
+        /// Retrieves the active RightController Detail Is Connected status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveRightControllerIsConnected => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).IsConnected;
+        /// <summary>
+        /// Retrieves the active RightController Detail Manufacturer status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveRightControllerManufacturer => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).Manufacturer;
+        /// <summary>
+        /// Retrieves the active RightController Detail Model status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveRightControllerModel => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).Model;
+        /// <summary>
+        /// Retrieves the active RightController Detail Tracking Type status that the TrackedAlias is using.
+        /// </summary>
+        public DeviceDetailsRecord.SpatialTrackingType ActiveRightControllerTrackingType => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).TrackingType;
+        /// <summary>
+        /// Retrieves the active RightController Detail Battery Level status that the TrackedAlias is using.
+        /// </summary>
+        public float ActiveRightControllerBatteryLevel => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).BatteryLevel;
+        /// <summary>
+        /// Retrieves the active RightController Detail Battery Charge status that the TrackedAlias is using.
+        /// </summary>
+        public BatteryStatus ActiveRightControllerBatteryChargeStatus => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).BatteryChargeStatus;
 
         /// <summary>
         /// Retrieves all of the linked CameraRig PlayAreas.
@@ -255,6 +416,60 @@
                         {
                             yield return headsetCamera;
                         }
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Retrieves all of the linked CameraRig Headset Device Detail Record.
+        /// </summary>
+        public IEnumerable<DeviceDetailsRecord> HeadsetDeviceDetailRecords
+        {
+            get
+            {
+                if (CameraRigs == null)
+                {
+                    yield break;
+                }
+
+                foreach (LinkedAliasAssociationCollection cameraRig in CameraRigs.NonSubscribableElements)
+                {
+                    if (cameraRig == null)
+                    {
+                        continue;
+                    }
+
+                    DeviceDetailsRecord headsetDetails = cameraRig.HeadsetDeviceDetails;
+                    if (headsetDetails != null)
+                    {
+                        yield return headsetDetails;
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Retrieves all of the linked CameraRig Dominant Controller Observers.
+        /// </summary>
+        public IEnumerable<DominantControllerObserver> DominantControllerObservers
+        {
+            get
+            {
+                if (CameraRigs == null)
+                {
+                    yield break;
+                }
+
+                foreach (LinkedAliasAssociationCollection cameraRig in CameraRigs.NonSubscribableElements)
+                {
+                    if (cameraRig == null)
+                    {
+                        continue;
+                    }
+
+                    DominantControllerObserver dominantController = cameraRig.DominantController;
+                    if (dominantController != null)
+                    {
+                        yield return dominantController;
                     }
                 }
             }
@@ -471,6 +686,60 @@
                     if (rightControllerHapticProfiles != null)
                     {
                         yield return rightControllerHapticProfiles;
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Retrieves all of the linked CameraRig Left Controller Device Detail Record.
+        /// </summary>
+        public IEnumerable<DeviceDetailsRecord> LeftControllerDeviceDetailRecords
+        {
+            get
+            {
+                if (CameraRigs == null)
+                {
+                    yield break;
+                }
+
+                foreach (LinkedAliasAssociationCollection cameraRig in CameraRigs.NonSubscribableElements)
+                {
+                    if (cameraRig == null)
+                    {
+                        continue;
+                    }
+
+                    DeviceDetailsRecord leftControllerDetails = cameraRig.LeftControllerDeviceDetails;
+                    if (leftControllerDetails != null)
+                    {
+                        yield return leftControllerDetails;
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Retrieves all of the linked CameraRig Right Controller Device Detail Record.
+        /// </summary>
+        public IEnumerable<DeviceDetailsRecord> RightControllerDeviceDetailRecords
+        {
+            get
+            {
+                if (CameraRigs == null)
+                {
+                    yield break;
+                }
+
+                foreach (LinkedAliasAssociationCollection cameraRig in CameraRigs.NonSubscribableElements)
+                {
+                    if (cameraRig == null)
+                    {
+                        continue;
+                    }
+
+                    DeviceDetailsRecord rightControllerDetails = cameraRig.RightControllerDeviceDetails;
+                    if (rightControllerDetails != null)
+                    {
+                        yield return rightControllerDetails;
                     }
                 }
             }
@@ -814,6 +1083,40 @@
                     {
                         return list;
                     }
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the first active <see cref="DominantControllerObserver"/> found in the given collection.
+        /// </summary>
+        /// <param name="collection">The collection to look for the first active in.</param>
+        /// <returns>The found first active element in the collection.</returns>
+        protected virtual DominantControllerObserver GetFirstActiveDominantControllerObserver(IEnumerable<DominantControllerObserver> collection)
+        {
+            foreach (DominantControllerObserver element in collection)
+            {
+                if (element.gameObject.activeInHierarchy)
+                {
+                    return element;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the first active <see cref="DeviceDetailsRecord"/> found in the given collection.
+        /// </summary>
+        /// <param name="collection">The collection to look for the first active in.</param>
+        /// <returns>The found first active element in the collection.</returns>
+        protected virtual DeviceDetailsRecord GetFirstActiveDeviceRecord(IEnumerable<DeviceDetailsRecord> collection)
+        {
+            foreach (DeviceDetailsRecord element in collection)
+            {
+                if (element.gameObject.activeInHierarchy)
+                {
+                    return element;
                 }
             }
             return null;


### PR DESCRIPTION
The DeviceDetailsRecord which can now be stored on a CameraRig is now
exposed via the TrackedAliasFacade so it's possible to get the current
CameraRig's device details as well as the current determined dominant
controller.

There are also new events that have been added to the Facade that
bubble up the events from the internal device records to make it
easier to know when device statuses change.