### PR TITLE
feat(prefab): provide dominant controller alias

### DIFF
--- a/Documentation/API/TrackedAliasConfigurator.md
+++ b/Documentation/API/TrackedAliasConfigurator.md
@@ -36,6 +36,8 @@ Sets up the Tracked Alias Prefab based on the provided user settings.
   * [RightControllerTrackingBegunEventHandler]
   * [RightControllerTrackingTypeChangedEventHandler]
 * [Properties]
+  * [DominantController]
+  * [DominantControllerVelocityTrackers]
   * [Facade]
   * [Headset]
   * [HeadsetOrigin]
@@ -57,8 +59,10 @@ Sets up the Tracked Alias Prefab based on the provided user settings.
   * [NotifyLeftControllerTrackingBegun()]
   * [NotifyRightControllerTrackingBegun()]
   * [NotifyTrackedAliasChanged(GameObject)]
+  * [OnDisable()]
   * [OnEnable()]
   * [SetUpCameraRigsConfiguration()]
+  * [SetUpDominantTracking(DeviceDetailsRecord)]
   * [SubscribeToDetailsEvents()]
   * [UnsubscribeToDetailsEvents()]
 
@@ -353,6 +357,26 @@ protected UnityAction<DeviceDetailsRecord.SpatialTrackingType> RightControllerTr
 
 ### Properties
 
+#### DominantController
+
+The ObjectFollower component for the current Dominant Controller.
+
+##### Declaration
+
+```
+public ObjectFollower DominantController { get; protected set; }
+```
+
+#### DominantControllerVelocityTrackers
+
+The VelocityTrackerProcessor component containing the current Dominant Controller Velocity Trackers.
+
+##### Declaration
+
+```
+public VelocityTrackerProcessor DominantControllerVelocityTrackers { get; protected set; }
+```
+
 #### Facade
 
 The public facade.
@@ -625,6 +649,14 @@ public virtual void NotifyTrackedAliasChanged(GameObject _)
 | --- | --- | --- |
 | GameObject | \_ | n/a |
 
+#### OnDisable()
+
+##### Declaration
+
+```
+protected virtual void OnDisable()
+```
+
 #### OnEnable()
 
 ##### Declaration
@@ -642,6 +674,22 @@ Sets up the TrackedAlias prefab with the specified settings.
 ```
 public virtual void SetUpCameraRigsConfiguration()
 ```
+
+#### SetUpDominantTracking(DeviceDetailsRecord)
+
+Sets up the dominant controller alias tracking.
+
+##### Declaration
+
+```
+public virtual void SetUpDominantTracking(DeviceDetailsRecord dominantRecord)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| DeviceDetailsRecord | dominantRecord | The current dominant controller record. |
 
 #### SubscribeToDetailsEvents()
 
@@ -698,6 +746,8 @@ protected virtual void UnsubscribeToDetailsEvents()
 [RightControllerTrackingBegunEventHandler]: #RightControllerTrackingBegunEventHandler
 [RightControllerTrackingTypeChangedEventHandler]: #RightControllerTrackingTypeChangedEventHandler
 [Properties]: #Properties
+[DominantController]: #DominantController
+[DominantControllerVelocityTrackers]: #DominantControllerVelocityTrackers
 [Facade]: #Facade
 [Headset]: #Headset
 [HeadsetOrigin]: #HeadsetOrigin
@@ -719,7 +769,9 @@ protected virtual void UnsubscribeToDetailsEvents()
 [NotifyLeftControllerTrackingBegun()]: #NotifyLeftControllerTrackingBegun
 [NotifyRightControllerTrackingBegun()]: #NotifyRightControllerTrackingBegun
 [NotifyTrackedAliasChanged(GameObject)]: #NotifyTrackedAliasChangedGameObject
+[OnDisable()]: #OnDisable
 [OnEnable()]: #OnEnable
 [SetUpCameraRigsConfiguration()]: #SetUpCameraRigsConfiguration
+[SetUpDominantTracking(DeviceDetailsRecord)]: #SetUpDominantTrackingDeviceDetailsRecord
 [SubscribeToDetailsEvents()]: #SubscribeToDetailsEvents
 [UnsubscribeToDetailsEvents()]: #UnsubscribeToDetailsEvents

--- a/Documentation/API/TrackedAliasFacade.md
+++ b/Documentation/API/TrackedAliasFacade.md
@@ -10,22 +10,37 @@ The public interface into the Tracked Alias Prefab.
 * [Fields]
   * [DominantControllerIsChanging]
   * [HeadsetBatteryChargeStatusChanged]
+  * [HeadsetBecameDominantController]
   * [HeadsetConnectionStatusChanged]
   * [HeadsetTrackingBegun]
   * [HeadsetTrackingTypeChanged]
   * [LeftControllerBatteryChargeStatusChanged]
+  * [LeftControllerBecameDominantController]
   * [LeftControllerConnectionStatusChanged]
   * [LeftControllerTrackingBegun]
   * [LeftControllerTrackingTypeChanged]
   * [RightControllerBatteryChargeStatusChanged]
+  * [RightControllerBecameDominantController]
   * [RightControllerConnectionStatusChanged]
   * [RightControllerTrackingBegun]
   * [RightControllerTrackingTypeChanged]
   * [TrackedAliasChanged]
 * [Properties]
+  * [ActiveDominantController]
+  * [ActiveDominantControllerBatteryChargeStatus]
+  * [ActiveDominantControllerBatteryLevel]
+  * [ActiveDominantControllerIsConnected]
+  * [ActiveDominantControllerManufacturer]
+  * [ActiveDominantControllerModel]
   * [ActiveDominantControllerNode]
   * [ActiveDominantControllerObserver]
   * [ActiveDominantControllerRecord]
+  * [ActiveDominantControllerTrackingHasBegun]
+  * [ActiveDominantControllerTrackingType]
+  * [ActiveDominantControllerVelocity]
+  * [ActiveDominantHapticProcess]
+  * [ActiveDominantHapticProfile]
+  * [ActiveDominantHapticProfiles]
   * [ActiveHeadset]
   * [ActiveHeadsetBatteryChargeStatus]
   * [ActiveHeadsetBatteryLevel]
@@ -44,6 +59,7 @@ The public interface into the Tracked Alias Prefab.
   * [ActiveLeftControllerIsConnected]
   * [ActiveLeftControllerManufacturer]
   * [ActiveLeftControllerModel]
+  * [ActiveLeftControllerNode]
   * [ActiveLeftControllerTrackingHasBegun]
   * [ActiveLeftControllerTrackingType]
   * [ActiveLeftControllerVelocity]
@@ -59,6 +75,7 @@ The public interface into the Tracked Alias Prefab.
   * [ActiveRightControllerIsConnected]
   * [ActiveRightControllerManufacturer]
   * [ActiveRightControllerModel]
+  * [ActiveRightControllerNode]
   * [ActiveRightControllerTrackingHasBegun]
   * [ActiveRightControllerTrackingType]
   * [ActiveRightControllerVelocity]
@@ -67,6 +84,7 @@ The public interface into the Tracked Alias Prefab.
   * [ActiveRightHapticProfiles]
   * [CameraRigs]
   * [Configuration]
+  * [DominantControllerAlias]
   * [DominantControllerObservers]
   * [HeadsetAlias]
   * [HeadsetCameras]
@@ -90,15 +108,24 @@ The public interface into the Tracked Alias Prefab.
   * [RightControllers]
   * [RightControllerVelocityTrackers]
 * [Methods]
+  * [BeginHapticProcessOnController(HapticProcess)]
+  * [BeginHapticProcessOnDominantController()]
+  * [BeginHapticProcessOnDominantController(Int32)]
   * [BeginHapticProcessOnLeftController()]
   * [BeginHapticProcessOnLeftController(Int32)]
   * [BeginHapticProcessOnRightController()]
   * [BeginHapticProcessOnRightController(Int32)]
   * [BeginHapticProfile(HapticProcessObservableList, Int32)]
+  * [CancelActiveHapticProfileOnDominantController()]
   * [CancelActiveHapticProfileOnLeftController()]
   * [CancelActiveHapticProfileOnRightController()]
+  * [CancelAllHapticsOnController(HapticProcessObservableList, HapticProcess, HapticProcess)]
+  * [CancelAllHapticsOnDominantController()]
   * [CancelAllHapticsOnLeftController()]
   * [CancelAllHapticsOnRightController()]
+  * [CancelHapticProcessOnController(HapticProcess)]
+  * [CancelHapticProcessOnDominantController()]
+  * [CancelHapticProcessOnDominantController(Int32)]
   * [CancelHapticProcessOnLeftController()]
   * [CancelHapticProcessOnLeftController(Int32)]
   * [CancelHapticProcessOnRightController()]
@@ -162,6 +189,16 @@ Emitted when the headset battery charge status changes.
 public DeviceDetailsRecord.BatteryStatusUnityEvent HeadsetBatteryChargeStatusChanged
 ```
 
+#### HeadsetBecameDominantController
+
+Emitted when the headset becomes the dominant controller.
+
+##### Declaration
+
+```
+public UnityEvent HeadsetBecameDominantController
+```
+
 #### HeadsetConnectionStatusChanged
 
 Emitted when the headset connection status changes.
@@ -202,6 +239,16 @@ Emitted when the left controller battery charge status changes.
 public DeviceDetailsRecord.BatteryStatusUnityEvent LeftControllerBatteryChargeStatusChanged
 ```
 
+#### LeftControllerBecameDominantController
+
+Emitted when the left controller becomes the dominant controller.
+
+##### Declaration
+
+```
+public UnityEvent LeftControllerBecameDominantController
+```
+
 #### LeftControllerConnectionStatusChanged
 
 Emitted when the left controller connection status changes.
@@ -240,6 +287,16 @@ Emitted when the right controller battery charge status changes.
 
 ```
 public DeviceDetailsRecord.BatteryStatusUnityEvent RightControllerBatteryChargeStatusChanged
+```
+
+#### RightControllerBecameDominantController
+
+Emitted when the right controller becomes the dominant controller.
+
+##### Declaration
+
+```
+public UnityEvent RightControllerBecameDominantController
 ```
 
 #### RightControllerConnectionStatusChanged
@@ -284,6 +341,66 @@ public TrackedAliasFacade.LinkedAliasAssociationCollectionUnityEvent TrackedAlia
 
 ### Properties
 
+#### ActiveDominantController
+
+Retrieves the active Dominant Controller GameObject that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public GameObject ActiveDominantController { get; }
+```
+
+#### ActiveDominantControllerBatteryChargeStatus
+
+Retrieves the active Dominant Controller Detail Battery Charge status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public BatteryStatus ActiveDominantControllerBatteryChargeStatus { get; }
+```
+
+#### ActiveDominantControllerBatteryLevel
+
+Retrieves the active Dominant Controller Detail Battery Level status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public float ActiveDominantControllerBatteryLevel { get; }
+```
+
+#### ActiveDominantControllerIsConnected
+
+Retrieves the active Dominant Controller Detail Is Connected status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveDominantControllerIsConnected { get; }
+```
+
+#### ActiveDominantControllerManufacturer
+
+Retrieves the active Dominant Controller Detail Manufacturer status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveDominantControllerManufacturer { get; }
+```
+
+#### ActiveDominantControllerModel
+
+Retrieves the active Dominant Controller Detail Model status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public string ActiveDominantControllerModel { get; }
+```
+
 #### ActiveDominantControllerNode
 
 Retrieves the dominant connected controller node.
@@ -306,12 +423,72 @@ public DominantControllerObserver ActiveDominantControllerObserver { get; }
 
 #### ActiveDominantControllerRecord
 
-Retrieves the dominant connected controller node.
+Retrieves the active Dominant Controller Detail Record that the TrackedAlias is using.
 
 ##### Declaration
 
 ```
 public DeviceDetailsRecord ActiveDominantControllerRecord { get; }
+```
+
+#### ActiveDominantControllerTrackingHasBegun
+
+Retrieves the active Dominant Controller Detail Tracking Begun status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public bool ActiveDominantControllerTrackingHasBegun { get; }
+```
+
+#### ActiveDominantControllerTrackingType
+
+Retrieves the active Dominant Controller Detail Tracking Type status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public DeviceDetailsRecord.SpatialTrackingType ActiveDominantControllerTrackingType { get; }
+```
+
+#### ActiveDominantControllerVelocity
+
+Retrieves the active Dominant Controller Velocity Tracker that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public VelocityTracker ActiveDominantControllerVelocity { get; }
+```
+
+#### ActiveDominantHapticProcess
+
+Retrieves the active Dominant Controller Haptic Process that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public HapticProcess ActiveDominantHapticProcess { get; }
+```
+
+#### ActiveDominantHapticProfile
+
+Retrieves the active Dominant Controller Haptic Profile that has been most recently used.
+
+##### Declaration
+
+```
+public HapticProcess ActiveDominantHapticProfile { get; protected set; }
+```
+
+#### ActiveDominantHapticProfiles
+
+Retrieves the active Dominant Controller Haptic Profiles that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public HapticProcessObservableList ActiveDominantHapticProfiles { get; }
 ```
 
 #### ActiveHeadset
@@ -426,7 +603,7 @@ public VelocityTracker ActiveHeadsetVelocity { get; }
 
 #### ActiveLeftController
 
-Retrieves the active Left Controller that the TrackedAlias is using.
+Retrieves the active Left Controller GameObject that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -436,7 +613,7 @@ public GameObject ActiveLeftController { get; }
 
 #### ActiveLeftControllerBatteryChargeStatus
 
-Retrieves the active LeftController Detail Battery Charge status that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Battery Charge status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -446,7 +623,7 @@ public BatteryStatus ActiveLeftControllerBatteryChargeStatus { get; }
 
 #### ActiveLeftControllerBatteryLevel
 
-Retrieves the active LeftController Detail Battery Level status that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Battery Level status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -456,7 +633,7 @@ public float ActiveLeftControllerBatteryLevel { get; }
 
 #### ActiveLeftControllerDetails
 
-Retrieves the active LeftController Detail Record that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Record that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -466,7 +643,7 @@ public DeviceDetailsRecord ActiveLeftControllerDetails { get; }
 
 #### ActiveLeftControllerIsConnected
 
-Retrieves the active LeftController Detail Is Connected status that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Is Connected status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -476,7 +653,7 @@ public bool ActiveLeftControllerIsConnected { get; }
 
 #### ActiveLeftControllerManufacturer
 
-Retrieves the active LeftController Detail Manufacturer status that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Manufacturer status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -486,7 +663,7 @@ public string ActiveLeftControllerManufacturer { get; }
 
 #### ActiveLeftControllerModel
 
-Retrieves the active LeftController Detail Model status that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Model status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -494,9 +671,19 @@ Retrieves the active LeftController Detail Model status that the TrackedAlias is
 public string ActiveLeftControllerModel { get; }
 ```
 
+#### ActiveLeftControllerNode
+
+Retrieves the left connected controller node.
+
+##### Declaration
+
+```
+public XRNode ActiveLeftControllerNode { get; }
+```
+
 #### ActiveLeftControllerTrackingHasBegun
 
-Retrieves the active LeftController Detail Tracking Begun status that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Tracking Begun status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -506,7 +693,7 @@ public bool ActiveLeftControllerTrackingHasBegun { get; }
 
 #### ActiveLeftControllerTrackingType
 
-Retrieves the active LeftController Detail Tracking Type status that the TrackedAlias is using.
+Retrieves the active Left Controller Detail Tracking Type status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -574,7 +761,7 @@ public GameObject ActivePlayArea { get; }
 
 #### ActiveRightController
 
-Retrieves the active Right Controller that the TrackedAlias is using.
+Retrieves the active Right Controller GameObject that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -584,7 +771,7 @@ public GameObject ActiveRightController { get; }
 
 #### ActiveRightControllerBatteryChargeStatus
 
-Retrieves the active RightController Detail Battery Charge status that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Battery Charge status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -594,7 +781,7 @@ public BatteryStatus ActiveRightControllerBatteryChargeStatus { get; }
 
 #### ActiveRightControllerBatteryLevel
 
-Retrieves the active RightController Detail Battery Level status that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Battery Level status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -604,7 +791,7 @@ public float ActiveRightControllerBatteryLevel { get; }
 
 #### ActiveRightControllerDetails
 
-Retrieves the active RightController Detail Record that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Record that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -614,7 +801,7 @@ public DeviceDetailsRecord ActiveRightControllerDetails { get; }
 
 #### ActiveRightControllerIsConnected
 
-Retrieves the active RightController Detail Is Connected status that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Is Connected status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -624,7 +811,7 @@ public bool ActiveRightControllerIsConnected { get; }
 
 #### ActiveRightControllerManufacturer
 
-Retrieves the active RightController Detail Manufacturer status that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Manufacturer status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -634,7 +821,7 @@ public string ActiveRightControllerManufacturer { get; }
 
 #### ActiveRightControllerModel
 
-Retrieves the active RightController Detail Model status that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Model status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -642,9 +829,19 @@ Retrieves the active RightController Detail Model status that the TrackedAlias i
 public string ActiveRightControllerModel { get; }
 ```
 
+#### ActiveRightControllerNode
+
+Retrieves the right connected controller node.
+
+##### Declaration
+
+```
+public XRNode ActiveRightControllerNode { get; }
+```
+
 #### ActiveRightControllerTrackingHasBegun
 
-Retrieves the active RightController Detail Tracking Begun status that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Tracking Begun status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -654,7 +851,7 @@ public bool ActiveRightControllerTrackingHasBegun { get; }
 
 #### ActiveRightControllerTrackingType
 
-Retrieves the active RightController Detail Tracking Type status that the TrackedAlias is using.
+Retrieves the active Right Controller Detail Tracking Type status that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -694,7 +891,7 @@ public HapticProcess ActiveRightHapticProfile { get; protected set; }
 
 #### ActiveRightHapticProfiles
 
-Retrieves the active Left Controller Haptic Profiles that the TrackedAlias is using.
+Retrieves the active Right Controller Haptic Profiles that the TrackedAlias is using.
 
 ##### Declaration
 
@@ -720,6 +917,16 @@ The linked Internal Setup.
 
 ```
 public TrackedAliasConfigurator Configuration { get; protected set; }
+```
+
+#### DominantControllerAlias
+
+The alias follower for the Dominant Controller.
+
+##### Declaration
+
+```
+public ObjectFollower DominantControllerAlias { get; }
 ```
 
 #### DominantControllerObservers
@@ -804,7 +1011,7 @@ public IEnumerable<VelocityTracker> HeadsetVelocityTrackers { get; }
 
 #### LeftControllerAlias
 
-The alias follower for the LeftController.
+The alias follower for the Left Controller.
 
 ##### Declaration
 
@@ -884,7 +1091,7 @@ public IEnumerable<GameObject> PlayAreas { get; }
 
 #### RightControllerAlias
 
-The alias follower for the RightController.
+The alias follower for the Right Controller.
 
 ##### Declaration
 
@@ -943,6 +1150,48 @@ public IEnumerable<VelocityTracker> RightControllerVelocityTrackers { get; }
 ```
 
 ### Methods
+
+#### BeginHapticProcessOnController(HapticProcess)
+
+Begins the haptic process on the given HapticProcess.
+
+##### Declaration
+
+```
+protected virtual void BeginHapticProcessOnController(HapticProcess process)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| HapticProcess | process | The process to begin. |
+
+#### BeginHapticProcessOnDominantController()
+
+Begins the haptic process on the Dominant Controller using the main HapticProcess.
+
+##### Declaration
+
+```
+public virtual void BeginHapticProcessOnDominantController()
+```
+
+#### BeginHapticProcessOnDominantController(Int32)
+
+Begins a haptic process on the Dominant Controller using the given profile.
+
+##### Declaration
+
+```
+public virtual void BeginHapticProcessOnDominantController(int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | profileIndex | The index of the haptic profile to use. |
 
 #### BeginHapticProcessOnLeftController()
 
@@ -1019,6 +1268,16 @@ protected virtual HapticProcess BeginHapticProfile(HapticProcessObservableList p
 | --- | --- |
 | HapticProcess | The haptic process being accessed. |
 
+#### CancelActiveHapticProfileOnDominantController()
+
+Cancels the haptic process currently running on the Left Controller for the current haptic profile.
+
+##### Declaration
+
+```
+public virtual void CancelActiveHapticProfileOnDominantController()
+```
+
 #### CancelActiveHapticProfileOnLeftController()
 
 Cancels the haptic process currently running on the Left Controller for the current haptic profile.
@@ -1037,6 +1296,34 @@ Cancels the haptic process currently running on the Right Controller for the cur
 
 ```
 public virtual void CancelActiveHapticProfileOnRightController()
+```
+
+#### CancelAllHapticsOnController(HapticProcessObservableList, HapticProcess, HapticProcess)
+
+Cancels all haptic process currently running on the specified Controller data.
+
+##### Declaration
+
+```
+protected virtual void CancelAllHapticsOnController(HapticProcessObservableList profileList, HapticProcess hapticProcess, HapticProcess hapticProfile)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| HapticProcessObservableList | profileList | The profile list to cancel. |
+| HapticProcess | hapticProcess | The specific process to cancel. |
+| HapticProcess | hapticProfile | The specific profile to cancel. |
+
+#### CancelAllHapticsOnDominantController()
+
+Cancels all haptic process currently running on the Dominant Controller.
+
+##### Declaration
+
+```
+public virtual void CancelAllHapticsOnDominantController()
 ```
 
 #### CancelAllHapticsOnLeftController()
@@ -1058,6 +1345,48 @@ Cancels all haptic process currently running on the Right Controller.
 ```
 public virtual void CancelAllHapticsOnRightController()
 ```
+
+#### CancelHapticProcessOnController(HapticProcess)
+
+Cancels any haptic process currently running on the specified HapticProcess.
+
+##### Declaration
+
+```
+protected virtual void CancelHapticProcessOnController(HapticProcess process)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| HapticProcess | process | The process to cancel. |
+
+#### CancelHapticProcessOnDominantController()
+
+Cancels any haptic process currently running on the Dominant Controller using the main HapticProcess.
+
+##### Declaration
+
+```
+public virtual void CancelHapticProcessOnDominantController()
+```
+
+#### CancelHapticProcessOnDominantController(Int32)
+
+Cancels the haptic process currently running on the Dominant Controller for the given profile.
+
+##### Declaration
+
+```
+public virtual void CancelHapticProcessOnDominantController(int profileIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | profileIndex | The index of the haptic profile to cancel. |
 
 #### CancelHapticProcessOnLeftController()
 
@@ -1448,22 +1777,37 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [Fields]: #Fields
 [DominantControllerIsChanging]: #DominantControllerIsChanging
 [HeadsetBatteryChargeStatusChanged]: #HeadsetBatteryChargeStatusChanged
+[HeadsetBecameDominantController]: #HeadsetBecameDominantController
 [HeadsetConnectionStatusChanged]: #HeadsetConnectionStatusChanged
 [HeadsetTrackingBegun]: #HeadsetTrackingBegun
 [HeadsetTrackingTypeChanged]: #HeadsetTrackingTypeChanged
 [LeftControllerBatteryChargeStatusChanged]: #LeftControllerBatteryChargeStatusChanged
+[LeftControllerBecameDominantController]: #LeftControllerBecameDominantController
 [LeftControllerConnectionStatusChanged]: #LeftControllerConnectionStatusChanged
 [LeftControllerTrackingBegun]: #LeftControllerTrackingBegun
 [LeftControllerTrackingTypeChanged]: #LeftControllerTrackingTypeChanged
 [RightControllerBatteryChargeStatusChanged]: #RightControllerBatteryChargeStatusChanged
+[RightControllerBecameDominantController]: #RightControllerBecameDominantController
 [RightControllerConnectionStatusChanged]: #RightControllerConnectionStatusChanged
 [RightControllerTrackingBegun]: #RightControllerTrackingBegun
 [RightControllerTrackingTypeChanged]: #RightControllerTrackingTypeChanged
 [TrackedAliasChanged]: #TrackedAliasChanged
 [Properties]: #Properties
+[ActiveDominantController]: #ActiveDominantController
+[ActiveDominantControllerBatteryChargeStatus]: #ActiveDominantControllerBatteryChargeStatus
+[ActiveDominantControllerBatteryLevel]: #ActiveDominantControllerBatteryLevel
+[ActiveDominantControllerIsConnected]: #ActiveDominantControllerIsConnected
+[ActiveDominantControllerManufacturer]: #ActiveDominantControllerManufacturer
+[ActiveDominantControllerModel]: #ActiveDominantControllerModel
 [ActiveDominantControllerNode]: #ActiveDominantControllerNode
 [ActiveDominantControllerObserver]: #ActiveDominantControllerObserver
 [ActiveDominantControllerRecord]: #ActiveDominantControllerRecord
+[ActiveDominantControllerTrackingHasBegun]: #ActiveDominantControllerTrackingHasBegun
+[ActiveDominantControllerTrackingType]: #ActiveDominantControllerTrackingType
+[ActiveDominantControllerVelocity]: #ActiveDominantControllerVelocity
+[ActiveDominantHapticProcess]: #ActiveDominantHapticProcess
+[ActiveDominantHapticProfile]: #ActiveDominantHapticProfile
+[ActiveDominantHapticProfiles]: #ActiveDominantHapticProfiles
 [ActiveHeadset]: #ActiveHeadset
 [ActiveHeadsetBatteryChargeStatus]: #ActiveHeadsetBatteryChargeStatus
 [ActiveHeadsetBatteryLevel]: #ActiveHeadsetBatteryLevel
@@ -1482,6 +1826,7 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [ActiveLeftControllerIsConnected]: #ActiveLeftControllerIsConnected
 [ActiveLeftControllerManufacturer]: #ActiveLeftControllerManufacturer
 [ActiveLeftControllerModel]: #ActiveLeftControllerModel
+[ActiveLeftControllerNode]: #ActiveLeftControllerNode
 [ActiveLeftControllerTrackingHasBegun]: #ActiveLeftControllerTrackingHasBegun
 [ActiveLeftControllerTrackingType]: #ActiveLeftControllerTrackingType
 [ActiveLeftControllerVelocity]: #ActiveLeftControllerVelocity
@@ -1497,6 +1842,7 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [ActiveRightControllerIsConnected]: #ActiveRightControllerIsConnected
 [ActiveRightControllerManufacturer]: #ActiveRightControllerManufacturer
 [ActiveRightControllerModel]: #ActiveRightControllerModel
+[ActiveRightControllerNode]: #ActiveRightControllerNode
 [ActiveRightControllerTrackingHasBegun]: #ActiveRightControllerTrackingHasBegun
 [ActiveRightControllerTrackingType]: #ActiveRightControllerTrackingType
 [ActiveRightControllerVelocity]: #ActiveRightControllerVelocity
@@ -1505,6 +1851,7 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [ActiveRightHapticProfiles]: #ActiveRightHapticProfiles
 [CameraRigs]: #CameraRigs
 [Configuration]: #Configuration
+[DominantControllerAlias]: #DominantControllerAlias
 [DominantControllerObservers]: #DominantControllerObservers
 [HeadsetAlias]: #HeadsetAlias
 [HeadsetCameras]: #HeadsetCameras
@@ -1528,15 +1875,24 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [RightControllers]: #RightControllers
 [RightControllerVelocityTrackers]: #RightControllerVelocityTrackers
 [Methods]: #Methods
+[BeginHapticProcessOnController(HapticProcess)]: #BeginHapticProcessOnControllerHapticProcess
+[BeginHapticProcessOnDominantController()]: #BeginHapticProcessOnDominantController
+[BeginHapticProcessOnDominantController(Int32)]: #BeginHapticProcessOnDominantControllerInt32
 [BeginHapticProcessOnLeftController()]: #BeginHapticProcessOnLeftController
 [BeginHapticProcessOnLeftController(Int32)]: #BeginHapticProcessOnLeftControllerInt32
 [BeginHapticProcessOnRightController()]: #BeginHapticProcessOnRightController
 [BeginHapticProcessOnRightController(Int32)]: #BeginHapticProcessOnRightControllerInt32
 [BeginHapticProfile(HapticProcessObservableList, Int32)]: #BeginHapticProfileHapticProcessObservableList-Int32
+[CancelActiveHapticProfileOnDominantController()]: #CancelActiveHapticProfileOnDominantController
 [CancelActiveHapticProfileOnLeftController()]: #CancelActiveHapticProfileOnLeftController
 [CancelActiveHapticProfileOnRightController()]: #CancelActiveHapticProfileOnRightController
+[CancelAllHapticsOnController(HapticProcessObservableList, HapticProcess, HapticProcess)]: #CancelAllHapticsOnControllerHapticProcessObservableList-HapticProcess-HapticProcess
+[CancelAllHapticsOnDominantController()]: #CancelAllHapticsOnDominantController
 [CancelAllHapticsOnLeftController()]: #CancelAllHapticsOnLeftController
 [CancelAllHapticsOnRightController()]: #CancelAllHapticsOnRightController
+[CancelHapticProcessOnController(HapticProcess)]: #CancelHapticProcessOnControllerHapticProcess
+[CancelHapticProcessOnDominantController()]: #CancelHapticProcessOnDominantController
+[CancelHapticProcessOnDominantController(Int32)]: #CancelHapticProcessOnDominantControllerInt32
 [CancelHapticProcessOnLeftController()]: #CancelHapticProcessOnLeftController
 [CancelHapticProcessOnLeftController(Int32)]: #CancelHapticProcessOnLeftControllerInt32
 [CancelHapticProcessOnRightController()]: #CancelHapticProcessOnRightController

--- a/Runtime/Prefabs/CameraRigs.TrackedAlias.prefab
+++ b/Runtime/Prefabs/CameraRigs.TrackedAlias.prefab
@@ -139,7 +139,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4709981995064440}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8318632670858740356
 MonoBehaviour:
@@ -409,9 +409,11 @@ MonoBehaviour:
   headsetOrigin: {fileID: 4112006815812048492}
   leftController: {fileID: 114355316302716346}
   rightController: {fileID: 114903452454151976}
+  dominantController: {fileID: 7318820795868674540}
   headsetVelocityTrackers: {fileID: 114855179307605532}
   leftControllerVelocityTrackers: {fileID: 114916227885696116}
   rightControllerVelocityTrackers: {fileID: 114394881288804734}
+  dominantControllerVelocityTrackers: {fileID: 5684276240579375230}
   validCameras: {fileID: 8318632670858740356}
   includeHeadsetSupplementCameras: 1
 --- !u!1 &1458957959020712
@@ -585,6 +587,7 @@ MonoBehaviour:
   - {fileID: 114838382803823290}
   - {fileID: 114439853570832652}
   - {fileID: 114131717192866960}
+  - {fileID: 6112870043005333250}
   - {fileID: 4171040980951338140}
 --- !u!1 &1540271613746846
 GameObject:
@@ -706,6 +709,7 @@ Transform:
   - {fileID: 4884265333994552}
   - {fileID: 4360459780143330}
   - {fileID: 4964578296126002}
+  - {fileID: 390116519711275921}
   - {fileID: 4406188199221008}
   m_Father: {fileID: 4419020640412130}
   m_RootOrder: 0
@@ -1238,6 +1242,78 @@ MonoBehaviour:
   currentIndex: 0
   elements:
   - {fileID: 1756652776302202}
+--- !u!1 &1089363882085133578
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 527052522676693761}
+  - component: {fileID: 7380267247884772175}
+  m_Layer: 0
+  m_Name: TargetOffsetCollection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &527052522676693761
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1089363882085133578}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5693567844781936115}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7380267247884772175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1089363882085133578}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements: []
 --- !u!1 &1116894810614227280
 GameObject:
   m_ObjectHideFlags: 0
@@ -1806,6 +1882,78 @@ MonoBehaviour:
       m_Calls: []
   currentIndex: 0
   elements: []
+--- !u!1 &3310280561320204861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9026048260650247854}
+  - component: {fileID: 224182517084592227}
+  m_Layer: 0
+  m_Name: VelocityTrackerCollection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9026048260650247854
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3310280561320204861}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3492861440160674291}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &224182517084592227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3310280561320204861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 74e0cf63a9a8d89409876f85cae7ae7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements: []
 --- !u!1 &3459563734610350754
 GameObject:
   m_ObjectHideFlags: 0
@@ -1951,6 +2099,145 @@ MonoBehaviour:
       m_Calls: []
   currentIndex: 0
   elements: []
+--- !u!1 &4278890802640975962
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 390116519711275921}
+  - component: {fileID: 6112870043005333250}
+  - component: {fileID: 7318820795868674540}
+  - component: {fileID: 5684276240579375230}
+  - component: {fileID: 2626039572408249704}
+  m_Layer: 0
+  m_Name: DominantControllerAlias
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &390116519711275921
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4278890802640975962}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3492861440160674291}
+  m_Father: {fileID: 4709981995064440}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6112870043005333250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4278890802640975962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 7318820795868674540}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0
+--- !u!114 &7318820795868674540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4278890802640975962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ActiveSourceChanging:
+    m_PersistentCalls:
+      m_Calls: []
+  ceaseAfterFirstSourceProcessed: 1
+  sources: {fileID: 5007130724785432930}
+  sourceValidity:
+    field: {fileID: 2626039572408249704}
+  targets: {fileID: 8054638150321827228}
+  targetValidity:
+    field: {fileID: 0}
+  targetOffsets: {fileID: 7380267247884772175}
+  followModifier: {fileID: 114809664867579310}
+  Preprocessed:
+    m_PersistentCalls:
+      m_Calls: []
+  Processed:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &5684276240579375230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4278890802640975962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60829535893427a45be5af6abd9f0426, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  velocityTrackers: {fileID: 224182517084592227}
+--- !u!114 &2626039572408249704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4278890802640975962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2e8b99b1ee7702478f1e9df767d7723, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoRejectStates: -1
+--- !u!1 &4423494590030987766
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3492861440160674291}
+  m_Layer: 0
+  m_Name: Collections
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3492861440160674291
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4423494590030987766}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5693567844781936115}
+  - {fileID: 9026048260650247854}
+  m_Father: {fileID: 390116519711275921}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4554267983074023489
 GameObject:
   m_ObjectHideFlags: 0
@@ -2483,6 +2770,112 @@ Transform:
   m_Father: {fileID: 4246440114407659285}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7443404685775281947
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6193932917442771534}
+  - component: {fileID: 8054638150321827228}
+  m_Layer: 0
+  m_Name: TargetCollection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6193932917442771534
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7443404685775281947}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5693567844781936115}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8054638150321827228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7443404685775281947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 4278890802640975962}
+--- !u!1 &7524904278991048472
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5693567844781936115}
+  m_Layer: 0
+  m_Name: FollowerCollections
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5693567844781936115
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7524904278991048472}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4565320417343581046}
+  - {fileID: 6193932917442771534}
+  - {fileID: 527052522676693761}
+  m_Father: {fileID: 3492861440160674291}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8030851138850232508
 GameObject:
   m_ObjectHideFlags: 0
@@ -2625,6 +3018,78 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8767623225079506361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements: []
+--- !u!1 &8799998212303053611
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4565320417343581046}
+  - component: {fileID: 5007130724785432930}
+  m_Layer: 0
+  m_Name: SourceCollection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4565320417343581046
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8799998212303053611}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5693567844781936115}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5007130724785432930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8799998212303053611}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7102cedb00f74625a1cdaa822e5661f5, type: 3}

--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -55,6 +55,10 @@
         [Header("Headset Events")]
         public UnityEvent HeadsetTrackingBegun = new UnityEvent();
         /// <summary>
+        /// Emitted when the headset becomes the dominant controller.
+        /// </summary>
+        public UnityEvent HeadsetBecameDominantController = new UnityEvent();
+        /// <summary>
         /// Emitted when the headset connection status changes.
         /// </summary>
         public DeviceDetailsRecord.BoolUnityEvent HeadsetConnectionStatusChanged = new DeviceDetailsRecord.BoolUnityEvent();
@@ -75,6 +79,10 @@
         [Header("Left Controller Events")]
         public UnityEvent LeftControllerTrackingBegun = new UnityEvent();
         /// <summary>
+        /// Emitted when the left controller becomes the dominant controller.
+        /// </summary>
+        public UnityEvent LeftControllerBecameDominantController = new UnityEvent();
+        /// <summary>
         /// Emitted when the left controller connection status changes.
         /// </summary>
         public DeviceDetailsRecord.BoolUnityEvent LeftControllerConnectionStatusChanged = new DeviceDetailsRecord.BoolUnityEvent();
@@ -94,6 +102,10 @@
         /// </summary>
         [Header("Right Controller Events")]
         public UnityEvent RightControllerTrackingBegun = new UnityEvent();
+        /// <summary>
+        /// Emitted when the right controller becomes the dominant controller.
+        /// </summary>
+        public UnityEvent RightControllerBecameDominantController = new UnityEvent();
         /// <summary>
         /// Emitted when the right controller connection status changes.
         /// </summary>
@@ -125,6 +137,8 @@
         /// <summary>
         /// Retrieves the active Headset that the TrackedAlias is using.
         /// </summary>
+
+        #region Headset Properties
         public GameObject ActiveHeadset => GetFirstActiveGameObject(Headsets);
         /// <summary>
         /// Retrieves the active Headset Camera that the TrackedAlias is using.
@@ -166,22 +180,80 @@
         /// Retrieves the active Headset Detail Battery Charge status that the TrackedAlias is using.
         /// </summary>
         public BatteryStatus ActiveHeadsetBatteryChargeStatus => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).BatteryChargeStatus;
+        #endregion
+
+        #region Dominant Controller Properties
         /// <summary>
         /// Retrieves the active Headset Detail Record that the TrackedAlias is using.
         /// </summary>
         public DominantControllerObserver ActiveDominantControllerObserver => GetFirstActiveDominantControllerObserver(DominantControllerObservers);
         /// <summary>
+        /// Retrieves the active Dominant Controller <see cref="GameObject"/> that the TrackedAlias is using.
+        /// </summary>
+        public GameObject ActiveDominantController => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.gameObject : null;
+        /// <summary>
         /// Retrieves the dominant connected controller node.
         /// </summary>
         public XRNode ActiveDominantControllerNode => ActiveDominantControllerObserver != null ? ActiveDominantControllerObserver.DominantController : XRNode.Head;
         /// <summary>
-        /// Retrieves the dominant connected controller node.
+        /// Retrieves the active Dominant Controller Velocity Tracker that the TrackedAlias is using.
+        /// </summary>
+        public VelocityTracker ActiveDominantControllerVelocity => Configuration.DominantControllerVelocityTrackers;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Haptic Process that the TrackedAlias is using.
+        /// </summary>
+        public HapticProcess ActiveDominantHapticProcess => ActiveDominantControllerObserver != null ? GetFirstActiveHapticProcess(ActiveDominantControllerObserver.DominantController == XRNode.LeftHand ? LeftControllerHapticProcesses : RightControllerHapticProcesses) : null;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Haptic Profiles that the TrackedAlias is using.
+        /// </summary>
+        public HapticProcessObservableList ActiveDominantHapticProfiles => ActiveDominantControllerObserver != null ? GetFirstActiveHapticProfile(ActiveDominantControllerObserver.DominantController == XRNode.LeftHand ? LeftControllerHapticProfiles : RightControllerHapticProfiles) : null;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Haptic Profile that has been most recently used.
+        /// </summary>
+        public HapticProcess ActiveDominantHapticProfile { get; protected set; }
+        /// <summary>
+        /// Retrieves the active Dominant Controller Detail Record that the TrackedAlias is using.
         /// </summary>
         public DeviceDetailsRecord ActiveDominantControllerRecord => ActiveDominantControllerObserver != null ? ActiveDominantControllerObserver.DominantControllerDetails : null;
         /// <summary>
-        /// Retrieves the active Left Controller that the TrackedAlias is using.
+        /// Retrieves the active Dominant Controller Detail Tracking Begun status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveDominantControllerTrackingHasBegun => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.TrackingHasBegun : false;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Detail Is Connected status that the TrackedAlias is using.
+        /// </summary>
+        public bool ActiveDominantControllerIsConnected => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.IsConnected : false;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Detail Manufacturer status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveDominantControllerManufacturer => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.Manufacturer : null;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Detail Model status that the TrackedAlias is using.
+        /// </summary>
+        public string ActiveDominantControllerModel => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.Model : null;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Detail Tracking Type status that the TrackedAlias is using.
+        /// </summary>
+        public DeviceDetailsRecord.SpatialTrackingType ActiveDominantControllerTrackingType => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.TrackingType : DeviceDetailsRecord.SpatialTrackingType.Unknown;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Detail Battery Level status that the TrackedAlias is using.
+        /// </summary>
+        public float ActiveDominantControllerBatteryLevel => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.BatteryLevel : -1f;
+        /// <summary>
+        /// Retrieves the active Dominant Controller Detail Battery Charge status that the TrackedAlias is using.
+        /// </summary>
+        public BatteryStatus ActiveDominantControllerBatteryChargeStatus => ActiveDominantControllerRecord != null ? ActiveDominantControllerRecord.BatteryChargeStatus : BatteryStatus.Unknown;
+        #endregion
+
+        #region Left Controller Properties
+        /// <summary>
+        /// Retrieves the active Left Controller <see cref="GameObject"/> that the TrackedAlias is using.
         /// </summary>
         public GameObject ActiveLeftController => GetFirstActiveGameObject(LeftControllers);
+        /// <summary>
+        /// Retrieves the left connected controller node.
+        /// </summary>
+        public XRNode ActiveLeftControllerNode => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).XRNodeType;
         /// <summary>
         /// Retrieves the active Left Controller Velocity Tracker that the TrackedAlias is using.
         /// </summary>
@@ -199,41 +271,48 @@
         /// </summary>
         public HapticProcess ActiveLeftHapticProfile { get; protected set; }
         /// <summary>
-        /// Retrieves the active LeftController Detail Record that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Record that the TrackedAlias is using.
         /// </summary>
         public DeviceDetailsRecord ActiveLeftControllerDetails => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords);
         /// <summary>
-        /// Retrieves the active LeftController Detail Tracking Begun status that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Tracking Begun status that the TrackedAlias is using.
         /// </summary>
         public bool ActiveLeftControllerTrackingHasBegun => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).TrackingHasBegun;
         /// <summary>
-        /// Retrieves the active LeftController Detail Is Connected status that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Is Connected status that the TrackedAlias is using.
         /// </summary>
         public bool ActiveLeftControllerIsConnected => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).IsConnected;
         /// <summary>
-        /// Retrieves the active LeftController Detail Manufacturer status that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Manufacturer status that the TrackedAlias is using.
         /// </summary>
         public string ActiveLeftControllerManufacturer => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).Manufacturer;
         /// <summary>
-        /// Retrieves the active LeftController Detail Model status that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Model status that the TrackedAlias is using.
         /// </summary>
         public string ActiveLeftControllerModel => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).Model;
         /// <summary>
-        /// Retrieves the active LeftController Detail Tracking Type status that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Tracking Type status that the TrackedAlias is using.
         /// </summary>
         public DeviceDetailsRecord.SpatialTrackingType ActiveLeftControllerTrackingType => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).TrackingType;
         /// <summary>
-        /// Retrieves the active LeftController Detail Battery Level status that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Battery Level status that the TrackedAlias is using.
         /// </summary>
         public float ActiveLeftControllerBatteryLevel => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).BatteryLevel;
         /// <summary>
-        /// Retrieves the active LeftController Detail Battery Charge status that the TrackedAlias is using.
+        /// Retrieves the active Left Controller Detail Battery Charge status that the TrackedAlias is using.
         /// </summary>
         public BatteryStatus ActiveLeftControllerBatteryChargeStatus => GetFirstActiveDeviceRecord(LeftControllerDeviceDetailRecords).BatteryChargeStatus;
+        #endregion
+
+        #region Right Controller Properties
         /// <summary>
-        /// Retrieves the active Right Controller that the TrackedAlias is using.
+        /// Retrieves the active Right Controller <see cref="GameObject"/> that the TrackedAlias is using.
         /// </summary>
         public GameObject ActiveRightController => GetFirstActiveGameObject(RightControllers);
+        /// <summary>
+        /// Retrieves the right connected controller node.
+        /// </summary>
+        public XRNode ActiveRightControllerNode => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).XRNodeType;
         /// <summary>
         /// Retrieves the active Right Controller Velocity Tracker that the TrackedAlias is using.
         /// </summary>
@@ -243,7 +322,7 @@
         /// </summary>
         public HapticProcess ActiveRightHapticProcess => GetFirstActiveHapticProcess(RightControllerHapticProcesses);
         /// <summary>
-        /// Retrieves the active Left Controller Haptic Profiles that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Haptic Profiles that the TrackedAlias is using.
         /// </summary>
         public HapticProcessObservableList ActiveRightHapticProfiles => GetFirstActiveHapticProfile(RightControllerHapticProfiles);
         /// <summary>
@@ -251,38 +330,40 @@
         /// </summary>
         public HapticProcess ActiveRightHapticProfile { get; protected set; }
         /// <summary>
-        /// Retrieves the active RightController Detail Record that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Record that the TrackedAlias is using.
         /// </summary>
         public DeviceDetailsRecord ActiveRightControllerDetails => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords);
         /// <summary>
-        /// Retrieves the active RightController Detail Tracking Begun status that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Tracking Begun status that the TrackedAlias is using.
         /// </summary>
         public bool ActiveRightControllerTrackingHasBegun => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).TrackingHasBegun;
         /// <summary>
-        /// Retrieves the active RightController Detail Is Connected status that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Is Connected status that the TrackedAlias is using.
         /// </summary>
         public bool ActiveRightControllerIsConnected => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).IsConnected;
         /// <summary>
-        /// Retrieves the active RightController Detail Manufacturer status that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Manufacturer status that the TrackedAlias is using.
         /// </summary>
         public string ActiveRightControllerManufacturer => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).Manufacturer;
         /// <summary>
-        /// Retrieves the active RightController Detail Model status that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Model status that the TrackedAlias is using.
         /// </summary>
         public string ActiveRightControllerModel => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).Model;
         /// <summary>
-        /// Retrieves the active RightController Detail Tracking Type status that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Tracking Type status that the TrackedAlias is using.
         /// </summary>
         public DeviceDetailsRecord.SpatialTrackingType ActiveRightControllerTrackingType => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).TrackingType;
         /// <summary>
-        /// Retrieves the active RightController Detail Battery Level status that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Battery Level status that the TrackedAlias is using.
         /// </summary>
         public float ActiveRightControllerBatteryLevel => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).BatteryLevel;
         /// <summary>
-        /// Retrieves the active RightController Detail Battery Charge status that the TrackedAlias is using.
+        /// Retrieves the active Right Controller Detail Battery Charge status that the TrackedAlias is using.
         /// </summary>
         public BatteryStatus ActiveRightControllerBatteryChargeStatus => GetFirstActiveDeviceRecord(RightControllerDeviceDetailRecords).BatteryChargeStatus;
+        #endregion
 
+        #region Enumerables
         /// <summary>
         /// Retrieves all of the linked CameraRig PlayAreas.
         /// </summary>
@@ -744,6 +825,9 @@
                 }
             }
         }
+        #endregion
+
+        #region Object Follower Properties
         /// <summary>
         /// The alias follower for the PlayArea.
         /// </summary>
@@ -757,25 +841,26 @@
         /// </summary>
         public ObjectFollower HeadsetOriginAlias => Configuration.HeadsetOrigin;
         /// <summary>
-        /// The alias follower for the LeftController.
+        /// The alias follower for the Left Controller.
         /// </summary>
         public ObjectFollower LeftControllerAlias => Configuration.LeftController;
         /// <summary>
-        /// The alias follower for the RightController.
+        /// The alias follower for the Right Controller.
         /// </summary>
         public ObjectFollower RightControllerAlias => Configuration.RightController;
+        /// <summary>
+        /// The alias follower for the Dominant Controller.
+        /// </summary>
+        public ObjectFollower DominantControllerAlias => Configuration.DominantController;
+        #endregion
 
+        #region Haptic Methods
         /// <summary>
         /// Begins the haptic process on the Left Controller using the main <see cref="HapticProcess"/>.
         /// </summary>
         public virtual void BeginHapticProcessOnLeftController()
         {
-            if (ActiveLeftHapticProcess == null)
-            {
-                return;
-            }
-
-            ActiveLeftHapticProcess.Begin();
+            BeginHapticProcessOnController(ActiveLeftHapticProcess);
         }
 
         /// <summary>
@@ -785,6 +870,10 @@
         public virtual void BeginHapticProcessOnLeftController(int profileIndex)
         {
             ActiveLeftHapticProfile = BeginHapticProfile(ActiveLeftHapticProfiles, profileIndex);
+            if (ActiveDominantControllerNode == ActiveLeftControllerNode)
+            {
+                ActiveDominantHapticProfile = ActiveLeftHapticProfile;
+            }
         }
 
         /// <summary>
@@ -792,12 +881,7 @@
         /// </summary>
         public virtual void BeginHapticProcessOnRightController()
         {
-            if (ActiveRightHapticProcess == null)
-            {
-                return;
-            }
-
-            ActiveRightHapticProcess.Begin();
+            BeginHapticProcessOnController(ActiveRightHapticProcess);
         }
 
         /// <summary>
@@ -807,6 +891,27 @@
         public virtual void BeginHapticProcessOnRightController(int profileIndex)
         {
             ActiveRightHapticProfile = BeginHapticProfile(ActiveRightHapticProfiles, profileIndex);
+            if (ActiveDominantControllerNode == ActiveRightControllerNode)
+            {
+                ActiveDominantHapticProfile = ActiveRightHapticProfile;
+            }
+        }
+
+        /// <summary>
+        /// Begins the haptic process on the Dominant Controller using the main <see cref="HapticProcess"/>.
+        /// </summary>
+        public virtual void BeginHapticProcessOnDominantController()
+        {
+            BeginHapticProcessOnController(ActiveDominantHapticProcess);
+        }
+
+        /// <summary>
+        /// Begins a haptic process on the Dominant Controller using the given profile.
+        /// </summary>
+        /// <param name="profileIndex">The index of the haptic profile to use.</param>
+        public virtual void BeginHapticProcessOnDominantController(int profileIndex)
+        {
+            ActiveDominantHapticProfile = BeginHapticProfile(ActiveDominantHapticProfiles, profileIndex);
         }
 
         /// <summary>
@@ -814,18 +919,15 @@
         /// </summary>
         public virtual void CancelAllHapticsOnLeftController()
         {
-            CancelHapticProcessOnLeftController();
-            CancelActiveHapticProfileOnLeftController();
+            CancelAllHapticsOnController(ActiveLeftHapticProfiles, ActiveLeftHapticProcess, ActiveLeftHapticProfile);
+        }
 
-            if (ActiveLeftHapticProfiles == null)
-            {
-                return;
-            }
-
-            foreach (HapticProcess process in ActiveLeftHapticProfiles.NonSubscribableElements)
-            {
-                process.Cancel();
-            }
+        /// <summary>
+        /// Cancels the haptic process currently running on the Left Controller for the current haptic profile.
+        /// </summary>
+        public virtual void CancelActiveHapticProfileOnLeftController()
+        {
+            CancelHapticProcessOnController(ActiveLeftHapticProfile);
         }
 
         /// <summary>
@@ -833,12 +935,7 @@
         /// </summary>
         public virtual void CancelHapticProcessOnLeftController()
         {
-            if (ActiveLeftHapticProcess == null)
-            {
-                return;
-            }
-
-            ActiveLeftHapticProcess.Cancel();
+            CancelHapticProcessOnController(ActiveLeftHapticProcess);
         }
 
         /// <summary>
@@ -852,48 +949,11 @@
         }
 
         /// <summary>
-        /// Cancels the haptic process currently running on the Left Controller for the current haptic profile.
-        /// </summary>
-        public virtual void CancelActiveHapticProfileOnLeftController()
-        {
-            if (ActiveLeftHapticProfile == null)
-            {
-                return;
-            }
-
-            ActiveLeftHapticProfile.Cancel();
-        }
-
-        /// <summary>
         /// Cancels all haptic process currently running on the Right Controller.
         /// </summary>
         public virtual void CancelAllHapticsOnRightController()
         {
-            CancelHapticProcessOnRightController();
-            CancelActiveHapticProfileOnRightController();
-
-            if (ActiveRightHapticProfiles == null)
-            {
-                return;
-            }
-
-            foreach (HapticProcess process in ActiveRightHapticProfiles.NonSubscribableElements)
-            {
-                process.Cancel();
-            }
-        }
-
-        /// <summary>
-        /// Cancels any haptic process currently running on the Right Controller using the main <see cref="HapticProcess"/>.
-        /// </summary>
-        public virtual void CancelHapticProcessOnRightController()
-        {
-            if (ActiveRightHapticProcess == null)
-            {
-                return;
-            }
-
-            ActiveRightHapticProcess.Cancel();
+            CancelAllHapticsOnController(ActiveRightHapticProfiles, ActiveRightHapticProcess, ActiveRightHapticProfile);
         }
 
         /// <summary>
@@ -901,12 +961,15 @@
         /// </summary>
         public virtual void CancelActiveHapticProfileOnRightController()
         {
-            if (ActiveRightHapticProfile == null)
-            {
-                return;
-            }
+            CancelHapticProcessOnController(ActiveRightHapticProfile);
+        }
 
-            ActiveRightHapticProfile.Cancel();
+        /// <summary>
+        /// Cancels any haptic process currently running on the Right Controller using the main <see cref="HapticProcess"/>.
+        /// </summary>
+        public virtual void CancelHapticProcessOnRightController()
+        {
+            CancelHapticProcessOnController(ActiveRightHapticProcess);
         }
 
         /// <summary>
@@ -918,6 +981,41 @@
             CancelHapticProfile(ActiveRightHapticProfiles, profileIndex);
             ActiveRightHapticProfile = null;
         }
+
+        /// <summary>
+        /// Cancels all haptic process currently running on the Dominant Controller.
+        /// </summary>
+        public virtual void CancelAllHapticsOnDominantController()
+        {
+            CancelAllHapticsOnController(ActiveDominantHapticProfiles, ActiveDominantHapticProcess, ActiveDominantHapticProfile);
+        }
+
+        /// <summary>
+        /// Cancels the haptic process currently running on the Left Controller for the current haptic profile.
+        /// </summary>
+        public virtual void CancelActiveHapticProfileOnDominantController()
+        {
+            CancelHapticProcessOnController(ActiveDominantHapticProfile);
+        }
+
+        /// <summary>
+        /// Cancels any haptic process currently running on the Dominant Controller using the main <see cref="HapticProcess"/>.
+        /// </summary>
+        public virtual void CancelHapticProcessOnDominantController()
+        {
+            CancelHapticProcessOnController(ActiveDominantHapticProcess);
+        }
+
+        /// <summary>
+        /// Cancels the haptic process currently running on the Dominant Controller for the given profile.
+        /// </summary>
+        /// <param name="profileIndex">The index of the haptic profile to cancel.</param>
+        public virtual void CancelHapticProcessOnDominantController(int profileIndex)
+        {
+            CancelHapticProfile(ActiveDominantHapticProfiles, profileIndex);
+            ActiveDominantHapticProfile = null;
+        }
+        #endregion
 
         protected virtual void OnEnable()
         {
@@ -1165,6 +1263,56 @@
         protected virtual bool IsValidHapticProfile(HapticProcessObservableList processes, int profileIndex)
         {
             return processes != null && profileIndex >= 0 && profileIndex < processes.NonSubscribableElements.Count;
+        }
+
+        /// <summary>
+        /// Begins the haptic process on the given <see cref="HapticProcess"/>.
+        /// </summary>
+        /// <param name="process">The process to begin.</param>
+        protected virtual void BeginHapticProcessOnController(HapticProcess process)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            process.Begin();
+        }
+
+        /// <summary>
+        /// Cancels all haptic process currently running on the specified Controller data.
+        /// </summary>
+        /// <param name="profileList">The profile list to cancel.</param>
+        /// <param name="hapticProcess">The specific process to cancel.</param>
+        /// <param name="hapticProfile">The specific profile to cancel.</param>
+        protected virtual void CancelAllHapticsOnController(HapticProcessObservableList profileList, HapticProcess hapticProcess, HapticProcess hapticProfile)
+        {
+            CancelHapticProcessOnController(hapticProcess);
+            CancelHapticProcessOnController(hapticProfile);
+
+            if (profileList == null)
+            {
+                return;
+            }
+
+            foreach (HapticProcess process in profileList.NonSubscribableElements)
+            {
+                process.Cancel();
+            }
+        }
+
+        /// <summary>
+        /// Cancels any haptic process currently running on the specified <see cref="HapticProcess"/>.
+        /// </summary>
+        /// <param name="process">The process to cancel.</param>
+        protected virtual void CancelHapticProcessOnController(HapticProcess process)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            process.Cancel();
         }
 
         /// <summary>


### PR DESCRIPTION
The dominant controller alias is now part of the TrackedAlias Aliases
collection and will track the position/orientation of whatever the
current dominant controller is.

This can be used to set up tracking objects to whatever the dominant
controller is rather than having to always use the left/right
controller.

There are also new events that are raised when the left/right
controller become dominant or when the headset becomes the dominant
controller.

Additional Facade properties for dominant controller data has also
been added for completeness.