### PR TITLE
feat(DeviceDetails): add endpoints for camera passthrough logic

### DIFF
--- a/Documentation/API/TrackedAliasConfigurator.md
+++ b/Documentation/API/TrackedAliasConfigurator.md
@@ -25,6 +25,8 @@ Sets up the Tracked Alias Prefab based on the provided user settings.
   * [DominantControllerIsChangingEventHandler]
   * [HeadsetBatteryChargeStatusChangedEventHandler]
   * [HeadsetConnectionChangedEventHandler]
+  * [HeadsetPassThroughCameraWasDisabledEventHandler]
+  * [HeadsetPassThroughCameraWasEnabledEventHandler]
   * [HeadsetTrackingBegunEventHandler]
   * [HeadsetTrackingTypeChangedEventHandler]
   * [LeftControllerBatteryChargeStatusChangedEventHandler]
@@ -253,6 +255,26 @@ The event handler to run when the bubbled headset event for connection changed i
 
 ```
 protected UnityAction<bool> HeadsetConnectionChangedEventHandler
+```
+
+#### HeadsetPassThroughCameraWasDisabledEventHandler
+
+The event handler to run when the bubbled headset event for passtrhrough camera disabled is raised.
+
+##### Declaration
+
+```
+protected UnityAction HeadsetPassThroughCameraWasDisabledEventHandler
+```
+
+#### HeadsetPassThroughCameraWasEnabledEventHandler
+
+The event handler to run when the bubbled headset event for passtrhrough camera enabled is raised.
+
+##### Declaration
+
+```
+protected UnityAction HeadsetPassThroughCameraWasEnabledEventHandler
 ```
 
 #### HeadsetTrackingBegunEventHandler
@@ -735,6 +757,8 @@ protected virtual void UnsubscribeToDetailsEvents()
 [DominantControllerIsChangingEventHandler]: #DominantControllerIsChangingEventHandler
 [HeadsetBatteryChargeStatusChangedEventHandler]: #HeadsetBatteryChargeStatusChangedEventHandler
 [HeadsetConnectionChangedEventHandler]: #HeadsetConnectionChangedEventHandler
+[HeadsetPassThroughCameraWasDisabledEventHandler]: #HeadsetPassThroughCameraWasDisabledEventHandler
+[HeadsetPassThroughCameraWasEnabledEventHandler]: #HeadsetPassThroughCameraWasEnabledEventHandler
 [HeadsetTrackingBegunEventHandler]: #HeadsetTrackingBegunEventHandler
 [HeadsetTrackingTypeChangedEventHandler]: #HeadsetTrackingTypeChangedEventHandler
 [LeftControllerBatteryChargeStatusChangedEventHandler]: #LeftControllerBatteryChargeStatusChangedEventHandler

--- a/Documentation/API/TrackedAliasFacade.md
+++ b/Documentation/API/TrackedAliasFacade.md
@@ -12,6 +12,8 @@ The public interface into the Tracked Alias Prefab.
   * [HeadsetBatteryChargeStatusChanged]
   * [HeadsetBecameDominantController]
   * [HeadsetConnectionStatusChanged]
+  * [HeadsetPassThroughCameraWasDisabled]
+  * [HeadsetPassThroughCameraWasEnabled]
   * [HeadsetTrackingBegun]
   * [HeadsetTrackingTypeChanged]
   * [LeftControllerBatteryChargeStatusChanged]
@@ -46,9 +48,11 @@ The public interface into the Tracked Alias Prefab.
   * [ActiveHeadsetBatteryLevel]
   * [ActiveHeadsetCamera]
   * [ActiveHeadsetDetails]
+  * [ActiveHeadsetHasPassThroughCamera]
   * [ActiveHeadsetIsConnected]
   * [ActiveHeadsetManufacturer]
   * [ActiveHeadsetModel]
+  * [ActiveHeadsetPassThroughCameraEnabled]
   * [ActiveHeadsetTrackingHasBegun]
   * [ActiveHeadsetTrackingType]
   * [ActiveHeadsetVelocity]
@@ -207,6 +211,26 @@ Emitted when the headset connection status changes.
 
 ```
 public DeviceDetailsRecord.BoolUnityEvent HeadsetConnectionStatusChanged
+```
+
+#### HeadsetPassThroughCameraWasDisabled
+
+Emitted when the pass through camera is disabled.
+
+##### Declaration
+
+```
+public UnityEvent HeadsetPassThroughCameraWasDisabled
+```
+
+#### HeadsetPassThroughCameraWasEnabled
+
+Emitted when the pass through camera is enabled.
+
+##### Declaration
+
+```
+public UnityEvent HeadsetPassThroughCameraWasEnabled
 ```
 
 #### HeadsetTrackingBegun
@@ -541,6 +565,16 @@ Retrieves the active Headset Detail Record that the TrackedAlias is using.
 public virtual DeviceDetailsRecord ActiveHeadsetDetails { get; }
 ```
 
+#### ActiveHeadsetHasPassThroughCamera
+
+Retrieves the active Headset Detail of whether it has a PassThrough Camera that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public virtual bool ActiveHeadsetHasPassThroughCamera { get; }
+```
+
 #### ActiveHeadsetIsConnected
 
 Retrieves the active Headset Detail Is Connected status that the TrackedAlias is using.
@@ -569,6 +603,16 @@ Retrieves the active Headset Detail Model status that the TrackedAlias is using.
 
 ```
 public virtual string ActiveHeadsetModel { get; }
+```
+
+#### ActiveHeadsetPassThroughCameraEnabled
+
+Gets or Sets the active Headset Passthrough Camera Enabled status that the TrackedAlias is using.
+
+##### Declaration
+
+```
+public virtual bool ActiveHeadsetPassThroughCameraEnabled { get; set; }
 ```
 
 #### ActiveHeadsetTrackingHasBegun
@@ -1779,6 +1823,8 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [HeadsetBatteryChargeStatusChanged]: #HeadsetBatteryChargeStatusChanged
 [HeadsetBecameDominantController]: #HeadsetBecameDominantController
 [HeadsetConnectionStatusChanged]: #HeadsetConnectionStatusChanged
+[HeadsetPassThroughCameraWasDisabled]: #HeadsetPassThroughCameraWasDisabled
+[HeadsetPassThroughCameraWasEnabled]: #HeadsetPassThroughCameraWasEnabled
 [HeadsetTrackingBegun]: #HeadsetTrackingBegun
 [HeadsetTrackingTypeChanged]: #HeadsetTrackingTypeChanged
 [LeftControllerBatteryChargeStatusChanged]: #LeftControllerBatteryChargeStatusChanged
@@ -1813,9 +1859,11 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [ActiveHeadsetBatteryLevel]: #ActiveHeadsetBatteryLevel
 [ActiveHeadsetCamera]: #ActiveHeadsetCamera
 [ActiveHeadsetDetails]: #ActiveHeadsetDetails
+[ActiveHeadsetHasPassThroughCamera]: #ActiveHeadsetHasPassThroughCamera
 [ActiveHeadsetIsConnected]: #ActiveHeadsetIsConnected
 [ActiveHeadsetManufacturer]: #ActiveHeadsetManufacturer
 [ActiveHeadsetModel]: #ActiveHeadsetModel
+[ActiveHeadsetPassThroughCameraEnabled]: #ActiveHeadsetPassThroughCameraEnabled
 [ActiveHeadsetTrackingHasBegun]: #ActiveHeadsetTrackingHasBegun
 [ActiveHeadsetTrackingType]: #ActiveHeadsetTrackingType
 [ActiveHeadsetVelocity]: #ActiveHeadsetVelocity

--- a/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
@@ -313,6 +313,14 @@
         /// The event handler to run when the bubbled headset event for battery charge status changed is raised.
         /// </summary>
         protected UnityAction<BatteryStatus> HeadsetBatteryChargeStatusChangedEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled headset event for passtrhrough camera enabled is raised.
+        /// </summary>
+        protected UnityAction HeadsetPassThroughCameraWasEnabledEventHandler;
+        /// <summary>
+        /// The event handler to run when the bubbled headset event for passtrhrough camera disabled is raised.
+        /// </summary>
+        protected UnityAction HeadsetPassThroughCameraWasDisabledEventHandler;
         #endregion
 
         #region Left Controller Data Cache
@@ -665,11 +673,15 @@
                 HeadsetConnectionChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedHeadsetConnectionStatus, Facade.HeadsetConnectionStatusChanged);
                 HeadsetTrackingTypeChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedHeadsetSpatialTrackingType, Facade.HeadsetTrackingTypeChanged);
                 HeadsetBatteryChargeStatusChangedEventHandler = (newValue) => CacheAndRaiseEventWithPayload(newValue, ref cachedHeadsetBatteryChargeStatus, Facade.HeadsetBatteryChargeStatusChanged);
+                HeadsetPassThroughCameraWasEnabledEventHandler = () => Facade.HeadsetPassThroughCameraWasEnabled?.Invoke();
+                HeadsetPassThroughCameraWasDisabledEventHandler = () => Facade.HeadsetPassThroughCameraWasDisabled?.Invoke();
 
                 Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.TrackingBegun.AddListener(HeadsetTrackingBegunEventHandler);
                 Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.ConnectionStatusChanged.AddListener(HeadsetConnectionChangedEventHandler);
                 Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.TrackingTypeChanged.AddListener(HeadsetTrackingTypeChangedEventHandler);
                 Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.BatteryChargeStatusChanged.AddListener(HeadsetBatteryChargeStatusChangedEventHandler);
+                Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.PassThroughCameraWasEnabled.AddListener(HeadsetPassThroughCameraWasEnabledEventHandler);
+                Facade.ActiveLinkedAliasAssociation.HeadsetDeviceDetails.PassThroughCameraWasDisabled.AddListener(HeadsetPassThroughCameraWasDisabledEventHandler);
             }
 
             if (Facade.ActiveLinkedAliasAssociation != null && Facade.ActiveLinkedAliasAssociation.LeftControllerDeviceDetails != null)
@@ -717,6 +729,8 @@
                 cachedLinkedAlias.HeadsetDeviceDetails.ConnectionStatusChanged.RemoveListener(HeadsetConnectionChangedEventHandler);
                 cachedLinkedAlias.HeadsetDeviceDetails.TrackingTypeChanged.RemoveListener(HeadsetTrackingTypeChangedEventHandler);
                 cachedLinkedAlias.HeadsetDeviceDetails.BatteryChargeStatusChanged.RemoveListener(HeadsetBatteryChargeStatusChangedEventHandler);
+                cachedLinkedAlias.HeadsetDeviceDetails.PassThroughCameraWasEnabled.RemoveListener(HeadsetPassThroughCameraWasEnabledEventHandler);
+                cachedLinkedAlias.HeadsetDeviceDetails.PassThroughCameraWasDisabled.RemoveListener(HeadsetPassThroughCameraWasDisabledEventHandler);
             }
 
             if (cachedLinkedAlias != null && cachedLinkedAlias.LeftControllerDeviceDetails != null)

--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -88,6 +88,14 @@
         /// Emitted when the headset battery charge status changes.
         /// </summary>
         public DeviceDetailsRecord.BatteryStatusUnityEvent HeadsetBatteryChargeStatusChanged = new DeviceDetailsRecord.BatteryStatusUnityEvent();
+        /// <summary>
+        /// Emitted when the pass through camera is enabled.
+        /// </summary>
+        public UnityEvent HeadsetPassThroughCameraWasEnabled = new UnityEvent();
+        /// <summary>
+        /// Emitted when the pass through camera is disabled.
+        /// </summary>
+        public UnityEvent HeadsetPassThroughCameraWasDisabled = new UnityEvent();
         #endregion
 
         #region Left Controller Events
@@ -211,6 +219,18 @@
         /// Retrieves the active Headset Detail Battery Charge status that the TrackedAlias is using.
         /// </summary>
         public virtual BatteryStatus ActiveHeadsetBatteryChargeStatus => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).BatteryChargeStatus;
+        /// <summary>
+        /// Retrieves the active Headset Detail of whether it has a PassThrough Camera that the TrackedAlias is using.
+        /// </summary>
+        public virtual bool ActiveHeadsetHasPassThroughCamera => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).HasPassThroughCamera;
+        /// <summary>
+        /// Gets or Sets the active Headset Passthrough Camera Enabled status that the TrackedAlias is using.
+        /// </summary>
+        public virtual bool ActiveHeadsetPassThroughCameraEnabled
+        {
+            get => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).PassThroughCameraEnabled;
+            set => GetFirstActiveDeviceRecord(HeadsetDeviceDetailRecords).PassThroughCameraEnabled = value;
+        }
         #endregion
 
         #region Dominant Controller Properties

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "2.6.0"
+        "io.extendreality.zinnia.unity": "2.7.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The DeviceDetails record now supports passthrough camera options so the TrackedAlias now provides endpoints for calling this logic on the tracked alias for the underlying SDK camerarig.