### PR TITLE
feat(Facade): add events for application focus and pause

### DIFF
--- a/Documentation/API/TrackedAliasConfigurator.md
+++ b/Documentation/API/TrackedAliasConfigurator.md
@@ -61,6 +61,8 @@ Sets up the Tracked Alias Prefab based on the provided user settings.
   * [NotifyLeftControllerTrackingBegun()]
   * [NotifyRightControllerTrackingBegun()]
   * [NotifyTrackedAliasChanged(GameObject)]
+  * [OnApplicationFocus(Boolean)]
+  * [OnApplicationPause(Boolean)]
   * [OnDisable()]
   * [OnEnable()]
   * [SetUpCameraRigsConfiguration()]
@@ -671,6 +673,34 @@ public virtual void NotifyTrackedAliasChanged(GameObject _)
 | --- | --- | --- |
 | GameObject | \_ | n/a |
 
+#### OnApplicationFocus(Boolean)
+
+##### Declaration
+
+```
+protected virtual void OnApplicationFocus(bool focusState)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Boolean | focusState | n/a |
+
+#### OnApplicationPause(Boolean)
+
+##### Declaration
+
+```
+protected virtual void OnApplicationPause(bool pauseState)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Boolean | pauseState | n/a |
+
 #### OnDisable()
 
 ##### Declaration
@@ -793,6 +823,8 @@ protected virtual void UnsubscribeToDetailsEvents()
 [NotifyLeftControllerTrackingBegun()]: #NotifyLeftControllerTrackingBegun
 [NotifyRightControllerTrackingBegun()]: #NotifyRightControllerTrackingBegun
 [NotifyTrackedAliasChanged(GameObject)]: #NotifyTrackedAliasChangedGameObject
+[OnApplicationFocus(Boolean)]: #OnApplicationFocusBoolean
+[OnApplicationPause(Boolean)]: #OnApplicationPauseBoolean
 [OnDisable()]: #OnDisable
 [OnEnable()]: #OnEnable
 [SetUpCameraRigsConfiguration()]: #SetUpCameraRigsConfiguration

--- a/Documentation/API/TrackedAliasFacade.md
+++ b/Documentation/API/TrackedAliasFacade.md
@@ -8,6 +8,10 @@ The public interface into the Tracked Alias Prefab.
 * [Namespace]
 * [Syntax]
 * [Fields]
+  * [ApplicationFocusLost]
+  * [ApplicationFocusResumed]
+  * [ApplicationPaused]
+  * [ApplicationResumeFromPaused]
   * [DominantControllerIsChanging]
   * [HeadsetBatteryChargeStatusChanged]
   * [HeadsetBecameDominantController]
@@ -172,6 +176,46 @@ public class TrackedAliasFacade : MonoBehaviour
 ```
 
 ### Fields
+
+#### ApplicationFocusLost
+
+Emitted when the application loses focus from being the active window.
+
+##### Declaration
+
+```
+public UnityEvent ApplicationFocusLost
+```
+
+#### ApplicationFocusResumed
+
+Emitted when the application resumes focus and becomes the active window.
+
+##### Declaration
+
+```
+public UnityEvent ApplicationFocusResumed
+```
+
+#### ApplicationPaused
+
+Emitted when the application pauses.
+
+##### Declaration
+
+```
+public UnityEvent ApplicationPaused
+```
+
+#### ApplicationResumeFromPaused
+
+Emitted when the application resumes from pause.
+
+##### Declaration
+
+```
+public UnityEvent ApplicationResumeFromPaused
+```
 
 #### DominantControllerIsChanging
 
@@ -1819,6 +1863,10 @@ protected virtual void UnsubscribeFromCameraRigsEvents()
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Fields]: #Fields
+[ApplicationFocusLost]: #ApplicationFocusLost
+[ApplicationFocusResumed]: #ApplicationFocusResumed
+[ApplicationPaused]: #ApplicationPaused
+[ApplicationResumeFromPaused]: #ApplicationResumeFromPaused
 [DominantControllerIsChanging]: #DominantControllerIsChanging
 [HeadsetBatteryChargeStatusChanged]: #HeadsetBatteryChargeStatusChanged
 [HeadsetBecameDominantController]: #HeadsetBecameDominantController

--- a/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
@@ -537,6 +537,30 @@
             Facade.DominantControllerIsChanging?.RemoveListener(SetUpDominantTracking);
         }
 
+        protected virtual void OnApplicationPause(bool pauseState)
+        {
+            if (pauseState)
+            {
+                Facade.ApplicationPaused?.Invoke();
+            }
+            else
+            {
+                Facade.ApplicationResumeFromPaused?.Invoke();
+            }
+        }
+
+        protected virtual void OnApplicationFocus(bool focusState)
+        {
+            if (focusState)
+            {
+                Facade.ApplicationFocusResumed?.Invoke();
+            }
+            else
+            {
+                Facade.ApplicationFocusLost?.Invoke();
+            }
+        }
+
         /// <summary>
         /// Checks if the two given values equal and raises the given event with the relevant payload if they are not.
         /// </summary>

--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -64,6 +64,22 @@
         /// Emitted when the dominant controller is changing.
         /// </summary>
         public DominantControllerObserver.UnityEvent DominantControllerIsChanging = new DominantControllerObserver.UnityEvent();
+        /// <summary>
+        /// Emitted when the application pauses.
+        /// </summary>
+        public UnityEvent ApplicationPaused = new UnityEvent();
+        /// <summary>
+        /// Emitted when the application resumes from pause.
+        /// </summary>
+        public UnityEvent ApplicationResumeFromPaused = new UnityEvent();
+        /// <summary>
+        /// Emitted when the application loses focus from being the active window.
+        /// </summary>
+        public UnityEvent ApplicationFocusLost = new UnityEvent();
+        /// <summary>
+        /// Emitted when the application resumes focus and becomes the active window.
+        /// </summary>
+        public UnityEvent ApplicationFocusResumed = new UnityEvent();
         #endregion
 
         #region Headset Events


### PR DESCRIPTION
Some new events have been added to the tracked alias to raise when the application gains focus and loses focus and when the application is paused or unpaused.