### PR TITLE
feat(Facade): emit event when the active camera changes

### DIFF
--- a/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasConfigurator.cs
@@ -285,6 +285,10 @@
         /// </summary>
         protected bool cachedHeadsetTrackingBegun;
         /// <summary>
+        /// The current cached <see cref="Camera"/>.
+        /// </summary>
+        protected Camera cachedCurrentCamera;
+        /// <summary>
         /// The current cached headset connection status.
         /// </summary>
         protected bool cachedHeadsetConnectionStatus;
@@ -499,6 +503,7 @@
 
             SubscribeToDetailsEvents();
             CheckExistingEventStatus();
+            Facade.HeadsetCameraChanged?.Invoke(Facade.ActiveLinkedAliasAssociation.HeadsetCamera);
             Facade.TrackedAliasChanged?.Invoke(Facade.ActiveLinkedAliasAssociation);
         }
 

--- a/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Runtime/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -24,6 +24,11 @@
         /// </summary>
         [Serializable]
         public class LinkedAliasAssociationCollectionUnityEvent : UnityEvent<LinkedAliasAssociationCollection> { }
+        /// <summary>
+        /// Defines the event with the <see cref="Camera"/>.
+        /// </summary>
+        [Serializable]
+        public class CameraUnityEvent : UnityEvent<Camera> { }
 
         #region Tracked Alias Settings
         [Header("Tracked Alias Settings")]
@@ -88,6 +93,10 @@
         /// </summary>
         [Header("Headset Events")]
         public UnityEvent HeadsetTrackingBegun = new UnityEvent();
+        /// <summary>
+        /// Emitted when the headset camera changes.
+        /// </summary>
+        public CameraUnityEvent HeadsetCameraChanged = new CameraUnityEvent();
         /// <summary>
         /// Emitted when the headset becomes the dominant controller.
         /// </summary>


### PR DESCRIPTION
The new HeadsetCameraChanged event will emit whenever the tracked alias changes and will emit the new headset camera belonging to the new tracked alias.